### PR TITLE
Create Astral Duel tactical board game

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,29 +2,125 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Ночной обход — Flappy</title>
+  <title>Астральный двор — дуэль стратегов</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <main class="layout">
-    <header class="header">
-      <h1>Ночной обход</h1>
-      <p class="subtitle">Помогите разведчику перелететь через прожекторы и пройдите как можно дальше.</p>
+  <main class="shell">
+    <header class="hero">
+      <div class="hero__text">
+        <p class="hero__overtitle">Тактическая дуэль на двоих</p>
+        <h1>Астральный двор</h1>
+        <p class="hero__subtitle">Управляйте эскадрами Орденов Рассвета и Сумрака, командуйте уникальными фигурами и переграйте соперника в поединке света и тени.</p>
+      </div>
+      <button type="button" id="new-game" class="hero__button">Новая партия</button>
     </header>
-    <section class="hud">
-      <div class="scoreboard" aria-live="polite">
-        <span>Счёт: <strong id="score">0</strong></span>
-        <span>Рекорд: <strong id="best">0</strong></span>
-      </div>
-      <div class="controls" aria-label="Управление">
-        <button id="start" type="button">Старт</button>
-        <button id="pause" type="button" disabled>Пауза</button>
-        <button id="restart" type="button" disabled>Заново</button>
-      </div>
-    </section>
-    <canvas id="game" width="400" height="600" role="img" aria-label="Игровое поле flappy bird"></canvas>
-    <p class="hint">Нажмите пробел, кликните по полю или коснитесь экрана, чтобы взмахнуть крыльями.</p>
+
+    <div class="layout">
+      <section class="board-area">
+        <div class="board-frame">
+          <div id="board" class="board" role="grid" aria-label="Игровое поле Астрального двора"></div>
+          <div id="endgame" class="endgame" aria-live="assertive" hidden>
+            <h2 id="endgame-title"></h2>
+            <p id="endgame-subtitle"></p>
+            <button type="button" id="play-again" class="endgame__button">Сыграть ещё</button>
+          </div>
+        </div>
+
+        <div id="status" class="status" role="status" aria-live="polite">
+          <p id="status-primary"></p>
+          <p id="status-secondary"></p>
+        </div>
+
+        <section class="log panel">
+          <div class="panel__title-row">
+            <h2 class="panel__title">Летопись ходов</h2>
+            <p class="panel__subtitle">Отслеживайте развитие дуэли по ходам</p>
+          </div>
+          <ol id="move-log" class="move-log" aria-live="polite"></ol>
+        </section>
+      </section>
+
+      <aside class="hud">
+        <section class="panel panel--players">
+          <h2 class="panel__title">Командование</h2>
+          <p class="panel__subtitle">Выберите фигуру своего ордена, чтобы вывести её характеристики.</p>
+          <div class="player-card" data-player="dawn">
+            <header class="player-card__header">
+              <div class="player-card__crest" aria-hidden="true"></div>
+              <div>
+                <h3>Орден Рассвета</h3>
+                <p class="player-card__tagline">Атакует молниеносно и удерживает пространство.</p>
+              </div>
+              <span id="turn-dawn" class="player-card__turn" aria-live="polite">Ход</span>
+            </header>
+            <div class="player-card__body">
+              <p class="player-card__label">Трофеи</p>
+              <div id="captured-dawn" class="captured" aria-label="Захвачено Орденом Рассвета"></div>
+            </div>
+          </div>
+
+          <div class="player-card" data-player="dusk">
+            <header class="player-card__header">
+              <div class="player-card__crest" aria-hidden="true"></div>
+              <div>
+                <h3>Клан Сумрака</h3>
+                <p class="player-card__tagline">Прессингует аккуратно и расставляет ловушки.</p>
+              </div>
+              <span id="turn-dusk" class="player-card__turn" aria-live="polite">Ожидает</span>
+            </header>
+            <div class="player-card__body">
+              <p class="player-card__label">Трофеи</p>
+              <div id="captured-dusk" class="captured" aria-label="Захвачено Кланом Сумрака"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel panel--focus">
+          <h2 class="panel__title">Досье фигуры</h2>
+          <article id="piece-focus" class="focus-card focus-card--empty" aria-live="polite">
+            <div class="focus-card__glyph" id="focus-glyph" aria-hidden="true">☆</div>
+            <div class="focus-card__text">
+              <h3 id="focus-name">Выберите фигуру, чтобы узнать её сильные стороны</h3>
+              <p id="focus-role"></p>
+              <p id="focus-summary"></p>
+              <p id="focus-movement" class="focus-card__movement"></p>
+              <p id="focus-position" class="focus-card__position"></p>
+              <p id="focus-status" class="focus-card__status"></p>
+              <p id="focus-promotion" class="focus-card__promotion"></p>
+            </div>
+            <div class="focus-card__traits">
+              <h4>Специализация</h4>
+              <ul id="focus-traits" class="tag-list"></ul>
+            </div>
+            <div class="focus-card__stats">
+              <h4>Параметры</h4>
+              <dl id="focus-stats" class="stat-list"></dl>
+            </div>
+          </article>
+        </section>
+
+        <section class="panel panel--codex">
+          <h2 class="panel__title">Кодекс фигур</h2>
+          <p class="panel__subtitle">Сила и роль каждого юнита</p>
+          <div id="codex" class="codex"></div>
+        </section>
+
+        <section class="panel panel--rules">
+          <h2 class="panel__title">Правила сражения</h2>
+          <ul class="rules">
+            <li>Игроки ходят по очереди, начиная с Ордена Рассвета.</li>
+            <li>Нельзя оставлять своего Командора под атакой после собственного хода.</li>
+            <li>Фигура берёт противника, если заканчивает ход на его клетке.</li>
+            <li>Рекруты, достигнув последней линии врага, повышаются до Странника.</li>
+            <li>Победа наступает при пленении Командора соперника или при мате. Если ходов нет и угрозы тоже — объявляется перемирие.</li>
+          </ul>
+        </section>
+      </aside>
+    </div>
   </main>
+  <span class="sr-only" id="live-region" role="status" aria-live="assertive"></span>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,377 +1,901 @@
 (function () {
-  const canvas = document.getElementById('game');
-  const ctx = canvas.getContext('2d');
+  const BOARD_SIZE = 6;
+  const COLUMN_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
+  const ROW_NUMBERS = [6, 5, 4, 3, 2, 1];
+  const directionByPlayer = { dawn: -1, dusk: 1 };
 
-  const ui = {
-    start: document.getElementById('start'),
-    pause: document.getElementById('pause'),
-    restart: document.getElementById('restart'),
-    score: document.getElementById('score'),
-    best: document.getElementById('best')
+  const PLAYERS = {
+    dawn: {
+      name: 'Орден Рассвета',
+      motto: 'Инициатива света',
+      color: '#f6d47f'
+    },
+    dusk: {
+      name: 'Клан Сумрака',
+      motto: 'Тактика тени',
+      color: '#7aa5ff'
+    }
   };
 
-  const CONFIG = {
-    gravity: 1800, // пикселей в секунду^2
-    flapStrength: -520,
-    pipeGap: 165,
-    pipeWidth: 70,
-    pipeSpeed: 210,
-    spawnInterval: 1.6,
-    minGapTop: 90,
-    groundHeight: 80
+  const PIECES = {
+    commander: {
+      name: 'Командор',
+      glyph: { dawn: '♔', dusk: '♚' },
+      role: 'Лидер',
+      description: 'Центр координации отряда. Командор обеспечивает связь и не может быть потерян.',
+      movement: 'Ходит на одну клетку в любом направлении.',
+      traits: ['Лидер', 'Тактическая аура'],
+      stats: { Манёвр: '★☆☆', Контроль: '★★★★★', Защита: '★★★★' }
+    },
+    sentinel: {
+      name: 'Страж',
+      glyph: { dawn: '♖', dusk: '♜' },
+      role: 'Линейный контроль',
+      description: 'Стражи держат прямые коридоры и отрезают пути отступления.',
+      movement: 'Любое количество клеток по горизонтали или вертикали без прыжков.',
+      traits: ['Линии давления', 'Гарнизон'],
+      stats: { Манёвр: '★★★', Контроль: '★★★★', Сложность: '★★' }
+    },
+    strider: {
+      name: 'Странник',
+      glyph: { dawn: '♗', dusk: '♝' },
+      role: 'Диагональный манёвр',
+      description: 'Странники режут пространство по диагоналям и выстраивают дуги обхода.',
+      movement: 'Любое количество клеток по диагонали без прыжков.',
+      traits: ['Фланг', 'Позиционный прессинг'],
+      stats: { Манёвр: '★★★★', Контроль: '★★★', Сложность: '★★☆' }
+    },
+    lancer: {
+      name: 'Гонец',
+      glyph: { dawn: '♘', dusk: '♞' },
+      role: 'Манёвр через заслоны',
+      description: 'Гонец прыгает дугой, прорывается через заслоны и наносит внезапные удары.',
+      movement: 'Прыжок буквой «Г»: две клетки в одном направлении и одна в перпендикулярном.',
+      traits: ['Скачок', 'Атака из тыла'],
+      stats: { Манёвр: '★★★★★', Контроль: '★★', Сложность: '★★★' }
+    },
+    squire: {
+      name: 'Рекрут',
+      glyph: { dawn: '♙', dusk: '♟' },
+      role: 'Линия фронта',
+      description: 'Рекруты выстраивают фронт. Врага берут по диагонали и могут сделать стартовый рывок.',
+      movement: 'На одну клетку вперёд (две при первом ходе). Захватывает по диагонали. На последней линии повышается до Странника.',
+      traits: ['Гарнизон', 'Повышение'],
+      stats: { Манёвр: '★★', Контроль: '★★', Сложность: '★' }
+    }
   };
 
-  const bird = {
-    x: canvas.width * 0.3,
-    y: canvas.height / 2,
-    radius: 18,
-    velocity: 0,
-    rotation: 0
+  const boardEl = document.getElementById('board');
+  const statusPrimaryEl = document.getElementById('status-primary');
+  const statusSecondaryEl = document.getElementById('status-secondary');
+  const moveLogEl = document.getElementById('move-log');
+  const codexEl = document.getElementById('codex');
+  const newGameButton = document.getElementById('new-game');
+  const playAgainButton = document.getElementById('play-again');
+  const liveRegion = document.getElementById('live-region');
+  const endgameEl = document.getElementById('endgame');
+  const endgameTitleEl = document.getElementById('endgame-title');
+  const endgameSubtitleEl = document.getElementById('endgame-subtitle');
+
+  const playerCards = {
+    dawn: document.querySelector('.player-card[data-player="dawn"]'),
+    dusk: document.querySelector('.player-card[data-player="dusk"]')
+  };
+  const turnBadges = {
+    dawn: document.getElementById('turn-dawn'),
+    dusk: document.getElementById('turn-dusk')
+  };
+  const capturedEls = {
+    dawn: document.getElementById('captured-dawn'),
+    dusk: document.getElementById('captured-dusk')
   };
 
-  const stars = Array.from({ length: 30 }, () => ({
-    x: Math.random() * canvas.width,
-    y: Math.random() * (canvas.height - CONFIG.groundHeight - 40),
-    radius: Math.random() * 1.5 + 0.5
-  }));
-
-  let pipes = [];
-  const state = {
-    mode: 'ready',
-    score: 0,
-    best: loadBestScore(),
-    lastTime: performance.now(),
-    spawnTimer: 0
+  const focusEls = {
+    card: document.getElementById('piece-focus'),
+    glyph: document.getElementById('focus-glyph'),
+    name: document.getElementById('focus-name'),
+    role: document.getElementById('focus-role'),
+    summary: document.getElementById('focus-summary'),
+    movement: document.getElementById('focus-movement'),
+    position: document.getElementById('focus-position'),
+    status: document.getElementById('focus-status'),
+    promotion: document.getElementById('focus-promotion'),
+    traits: document.getElementById('focus-traits'),
+    stats: document.getElementById('focus-stats')
   };
 
-  let animationId = null;
+  let board = [];
+  let cellElements = [];
+  let currentPlayer = 'dawn';
+  let selectedCell = null;
+  let legalMoves = [];
+  let legalMoveMap = new Map();
+  let capturedPieces = { dawn: [], dusk: [] };
+  let moveHistory = [];
+  let gameState = 'idle';
+  let winner = null;
 
-  function loadBestScore() {
-    const raw = localStorage.getItem('mazepark-flappy-best');
-    const value = parseInt(raw, 10);
-    return Number.isFinite(value) && value >= 0 ? value : 0;
+  newGameButton.addEventListener('click', startNewGame);
+  playAgainButton.addEventListener('click', startNewGame);
+
+  function start() {
+    buildBoardSkeleton();
+    populateCodex();
+    startNewGame();
   }
 
-  function saveBestScore() {
-    localStorage.setItem('mazepark-flappy-best', String(state.best));
+  function startNewGame() {
+    board = createInitialBoard();
+    currentPlayer = 'dawn';
+    selectedCell = null;
+    legalMoves = [];
+    legalMoveMap.clear();
+    capturedPieces = { dawn: [], dusk: [] };
+    moveHistory = [];
+    gameState = 'playing';
+    winner = null;
+    endgameEl.hidden = true;
+    renderBoard();
+    updateHighlights();
+    updateCaptured();
+    renderMoveLog();
+    updatePieceFocus(null);
+    updateTurnPanel();
+    updateStatus('Орден Рассвета начинает партию.', 'Выберите фигуру, чтобы совершить первый ход.');
   }
 
-  function resetEntities() {
-    state.score = 0;
-    state.spawnTimer = 0;
-    bird.y = canvas.height / 2;
-    bird.velocity = 0;
-    bird.rotation = 0;
-    pipes = [];
-    updateScoreboard();
-  }
+  function buildBoardSkeleton() {
+    boardEl.innerHTML = '';
+    boardEl.style.setProperty('--board-size', BOARD_SIZE);
+    cellElements = Array.from({ length: BOARD_SIZE }, () => []);
 
-  function updateScoreboard() {
-    ui.score.textContent = state.score;
-    ui.best.textContent = state.best;
-  }
-
-  function applyUiState() {
-    ui.start.disabled = state.mode === 'running';
-    ui.pause.disabled = !(state.mode === 'running' || state.mode === 'paused');
-    ui.restart.disabled = state.mode === 'ready';
-    ui.pause.textContent = state.mode === 'paused' ? 'Продолжить' : 'Пауза';
-  }
-
-  function flap() {
-    bird.velocity = CONFIG.flapStrength;
-  }
-
-  function beginGame() {
-    resetEntities();
-    state.mode = 'running';
-    state.lastTime = performance.now();
-    applyUiState();
-    flap();
-  }
-
-  function togglePause() {
-    if (state.mode === 'running') {
-      state.mode = 'paused';
-      applyUiState();
-    } else if (state.mode === 'paused') {
-      state.mode = 'running';
-      state.lastTime = performance.now();
-      applyUiState();
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const cell = document.createElement('button');
+        cell.type = 'button';
+        cell.className = `cell ${(row + col) % 2 === 0 ? 'cell--light' : 'cell--dark'}`;
+        cell.dataset.row = row;
+        cell.dataset.col = col;
+        cell.dataset.coord = toNotation(row, col);
+        cell.setAttribute('aria-label', `Клетка ${toNotation(row, col)}`);
+        cell.addEventListener('click', handleCellClick);
+        boardEl.appendChild(cell);
+        cellElements[row][col] = cell;
+      }
     }
   }
 
-  function gameOver() {
-    if (state.mode === 'gameover') return;
-    state.mode = 'gameover';
-    if (state.score > state.best) {
-      state.best = state.score;
-      saveBestScore();
+  function handleCellClick(event) {
+    if (gameState !== 'playing') {
+      return;
     }
-    updateScoreboard();
-    applyUiState();
+
+    const cell = event.currentTarget;
+    const row = Number(cell.dataset.row);
+    const col = Number(cell.dataset.col);
+    const piece = board[row][col];
+
+    const key = `${row},${col}`;
+    const move = legalMoveMap.get(key);
+    if (move && selectedCell) {
+      executeMove(selectedCell.row, selectedCell.col, move);
+      return;
+    }
+
+    if (selectedCell && selectedCell.row === row && selectedCell.col === col) {
+      selectedCell = null;
+      setLegalMoves([]);
+      updateHighlights();
+      updatePieceFocus(null);
+      updateStatus(`${PLAYERS[currentPlayer].name} ожидает решения.`, 'Вы можете выбрать другую фигуру.');
+      return;
+    }
+
+    if (!piece) {
+      selectedCell = null;
+      setLegalMoves([]);
+      updateHighlights();
+      updatePieceFocus(null);
+      return;
+    }
+
+    updatePieceFocus(piece, row, col);
+
+    if (piece.owner !== currentPlayer) {
+      setLegalMoves([]);
+      selectedCell = null;
+      updateHighlights();
+      updateStatus(`${PLAYERS[currentPlayer].name} ходит.`, 'Вы можете только изучить фигуры соперника.');
+      return;
+    }
+
+    const moves = getLegalMoves(row, col);
+    selectedCell = { row, col };
+    setLegalMoves(moves);
+    updateHighlights();
+    if (moves.length === 0) {
+      updateStatus(`${PIECES[piece.type].name} заблокирован.`, 'Выберите другую фигуру для манёвра.');
+    } else {
+      const coords = moves.map((m) => toNotation(m.row, m.col)).join(', ');
+      updateStatus(`${PIECES[piece.type].name} готов к манёвру.`, `Доступные клетки: ${coords}.`);
+    }
   }
 
-  function spawnPipe() {
-    const clearance = CONFIG.pipeGap;
-    const maxTop = canvas.height - CONFIG.groundHeight - clearance - CONFIG.minGapTop;
-    const gapTop = CONFIG.minGapTop + Math.random() * Math.max(10, maxTop);
-    pipes.push({
-      x: canvas.width + CONFIG.pipeWidth,
-      width: CONFIG.pipeWidth,
-      gapTop,
-      gapBottom: gapTop + clearance,
-      scored: false
+  function executeMove(fromRow, fromCol, move) {
+    const piece = board[fromRow][fromCol];
+    if (!piece) {
+      return;
+    }
+
+    const target = board[move.row][move.col];
+    const originalType = piece.type;
+    const opponent = otherPlayer(piece.owner);
+    const notation = `${toNotation(fromRow, fromCol)} → ${toNotation(move.row, move.col)}`;
+
+    if (target) {
+      capturedPieces[piece.owner].push(target.type);
+    }
+
+    board[move.row][move.col] = piece;
+    board[fromRow][fromCol] = null;
+    piece.moved = true;
+
+    let promotionType = null;
+    if (move.promotion) {
+      promotionType = move.promotion;
+      piece.promotedFrom = piece.promotedFrom || piece.type;
+      piece.type = promotionType;
+    }
+
+    const moveEntry = {
+      player: piece.owner,
+      pieceType: originalType,
+      notation,
+      capture: Boolean(target),
+      promotion: promotionType,
+      check: false,
+      checkmate: false,
+      stalemate: false
+    };
+
+    const victoryByCapture = target && target.type === 'commander';
+
+    selectedCell = null;
+    setLegalMoves([]);
+    renderBoard();
+    updateCaptured();
+
+    if (victoryByCapture) {
+      moveEntry.checkmate = true;
+      moveHistory.push(moveEntry);
+      finalizeGame(piece.owner, `${PIECES[originalType].name} пленил Командора ${PLAYERS[opponent].name}.`, 'Решающее столкновение завершило поединок.');
+      return;
+    }
+
+    const opponentCommander = findCommander(board, opponent);
+    const givesCheck = opponentCommander ? isSquareUnderAttack(board, opponentCommander.row, opponentCommander.col, piece.owner) : false;
+    moveEntry.check = givesCheck;
+    moveHistory.push(moveEntry);
+
+    currentPlayer = opponent;
+
+    const opponentHasMoves = hasLegalMoves(board, opponent);
+    const opponentInCheck = isCommanderInCheck(board, opponent);
+
+    if (!opponentHasMoves) {
+      if (opponentInCheck) {
+        moveEntry.checkmate = true;
+        finalizeGame(piece.owner, `${PLAYERS[piece.owner].name} ставит мат.`, `${PLAYERS[opponent].name} не может спасти Командора.`);
+      } else {
+        moveEntry.stalemate = true;
+        finalizeGame(null, 'Перемирие — пат.', 'Оба ордена выдыхают и объявляют ничью.');
+      }
+      renderMoveLog();
+      return;
+    }
+
+    renderMoveLog();
+    updatePieceFocus(null);
+    updateTurnPanel();
+
+    const actorName = PLAYERS[piece.owner].name;
+    const opponentName = PLAYERS[opponent].name;
+    let primary = `${actorName} перемещает ${PIECES[originalType].name} на ${toNotation(move.row, move.col)}.`;
+    if (target) {
+      primary += ` Взято: ${PIECES[target.type].name}.`;
+    }
+    if (promotionType) {
+      primary += ` Повышение до ${PIECES[piece.type].name}.`;
+    }
+
+    let secondary;
+    if (givesCheck) {
+      secondary = `${opponentName}, ваш Командор под прицелом!`;
+    } else if (opponentInCheck) {
+      secondary = `${opponentName}, ваш Командор всё ещё под угрозой.`;
+    } else {
+      secondary = `${opponentName}, ваш ход.`;
+    }
+
+    updateStatus(primary, secondary);
+    updateHighlights();
+    updateCommanderAlerts();
+  }
+
+  function finalizeGame(winningPlayer, title, subtitle) {
+    gameState = 'ended';
+    winner = winningPlayer;
+    selectedCell = null;
+    setLegalMoves([]);
+    updateHighlights();
+    updateCommanderAlerts();
+    updateTurnPanel();
+
+    const heading = winningPlayer ? `${PLAYERS[winningPlayer].name} побеждает!` : title;
+    const detail = subtitle;
+
+    endgameTitleEl.textContent = heading;
+    endgameSubtitleEl.textContent = detail;
+    endgameEl.hidden = false;
+    updateStatus(heading, detail);
+    renderMoveLog();
+  }
+
+  function setLegalMoves(moves) {
+    legalMoves = moves;
+    legalMoveMap = new Map();
+    moves.forEach((move) => {
+      legalMoveMap.set(`${move.row},${move.col}`, move);
     });
   }
 
-  function updateGame(delta) {
-    state.spawnTimer += delta;
-    if (state.spawnTimer >= CONFIG.spawnInterval) {
-      state.spawnTimer = 0;
-      spawnPipe();
-    }
-
-    bird.velocity += CONFIG.gravity * delta;
-    bird.y += bird.velocity * delta;
-    bird.rotation = Math.atan2(bird.velocity, CONFIG.pipeSpeed * 2);
-
-    const ceiling = bird.radius;
-    const floor = canvas.height - CONFIG.groundHeight - bird.radius;
-    if (bird.y < ceiling) {
-      bird.y = ceiling;
-      bird.velocity = 0;
-    }
-    if (bird.y > floor) {
-      bird.y = floor;
-      gameOver();
-    }
-
-    const nextPipes = [];
-    for (const pipe of pipes) {
-      pipe.x -= CONFIG.pipeSpeed * delta;
-      if (!pipe.scored && pipe.x + pipe.width < bird.x - bird.radius) {
-        pipe.scored = true;
-        state.score += 1;
-        updateScoreboard();
+  function renderBoard() {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const cell = cellElements[row][col];
+        const piece = board[row][col];
+        cell.innerHTML = '';
+        cell.classList.remove('cell--alert');
+        if (!piece) {
+          cell.setAttribute('aria-label', `Пустая клетка ${toNotation(row, col)}`);
+          continue;
+        }
+        const def = PIECES[piece.type];
+        const wrapper = document.createElement('div');
+        wrapper.className = `piece piece--${piece.owner} piece--${piece.type}`;
+        const glyph = document.createElement('span');
+        glyph.className = 'piece__glyph';
+        glyph.setAttribute('aria-hidden', 'true');
+        glyph.textContent = def.glyph[piece.owner];
+        const sr = document.createElement('span');
+        sr.className = 'sr-only';
+        sr.textContent = `${def.name} игрока ${PLAYERS[piece.owner].name}`;
+        wrapper.appendChild(glyph);
+        wrapper.appendChild(sr);
+        cell.appendChild(wrapper);
+        cell.setAttribute('aria-label', `${def.name} ${PLAYERS[piece.owner].name} на клетке ${toNotation(row, col)}`);
       }
-      if (pipe.x + pipe.width > 0) {
-        nextPipes.push(pipe);
-      }
+    }
+    updateCommanderAlerts();
+  }
 
-      if (bird.x + bird.radius > pipe.x && bird.x - bird.radius < pipe.x + pipe.width) {
-        if (bird.y - bird.radius < pipe.gapTop || bird.y + bird.radius > pipe.gapBottom) {
-          gameOver();
+  function updateHighlights() {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const cell = cellElements[row][col];
+        cell.classList.remove('cell--selected', 'cell--move', 'cell--capture');
+        if (selectedCell && selectedCell.row === row && selectedCell.col === col) {
+          cell.classList.add('cell--selected');
+        }
+        const key = `${row},${col}`;
+        if (legalMoveMap.has(key)) {
+          const move = legalMoveMap.get(key);
+          cell.classList.add(move.capture ? 'cell--capture' : 'cell--move');
         }
       }
     }
-    pipes = nextPipes;
   }
 
-  function drawBackground() {
-    const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-    gradient.addColorStop(0, '#060915');
-    gradient.addColorStop(0.55, '#102040');
-    gradient.addColorStop(1, '#182d52');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    ctx.save();
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-    for (const star of stars) {
-      ctx.beginPath();
-      ctx.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
-      ctx.fill();
+  function updateCommanderAlerts() {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        cellElements[row][col].classList.remove('cell--alert');
+      }
     }
-    ctx.restore();
+    const players = ['dawn', 'dusk'];
+    players.forEach((player) => {
+      const commander = findCommander(board, player);
+      if (!commander) {
+        return;
+      }
+      const cell = cellElements[commander.row][commander.col];
+      if (isCommanderInCheck(board, player)) {
+        cell.classList.add('cell--alert');
+      }
+    });
   }
 
-  function drawGround() {
-    ctx.fillStyle = '#1a2d4d';
-    ctx.fillRect(0, canvas.height - CONFIG.groundHeight, canvas.width, CONFIG.groundHeight);
-    ctx.strokeStyle = '#253d63';
-    ctx.lineWidth = 4;
-    ctx.beginPath();
-    ctx.moveTo(0, canvas.height - CONFIG.groundHeight);
-    ctx.lineTo(canvas.width, canvas.height - CONFIG.groundHeight);
-    ctx.stroke();
-  }
-
-  function drawPipes() {
-    for (const pipe of pipes) {
-      const gradient = ctx.createLinearGradient(pipe.x, 0, pipe.x + pipe.width, 0);
-      gradient.addColorStop(0, '#1ad6ff');
-      gradient.addColorStop(1, '#1a90ff');
-      ctx.fillStyle = gradient;
-
-      ctx.fillRect(pipe.x, 0, pipe.width, pipe.gapTop);
-      ctx.fillRect(pipe.x, pipe.gapBottom, pipe.width, canvas.height - CONFIG.groundHeight - pipe.gapBottom);
-
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
-      ctx.fillRect(pipe.x, pipe.gapTop - 12, pipe.width, 12);
-      ctx.fillRect(pipe.x, pipe.gapBottom, pipe.width, 12);
+  function updateStatus(primary, secondary = '', announce = true) {
+    statusPrimaryEl.textContent = primary;
+    statusSecondaryEl.textContent = secondary;
+    if (announce) {
+      const combined = `${primary} ${secondary}`.trim();
+      liveRegion.textContent = combined;
+      window.setTimeout(() => {
+        liveRegion.textContent = '';
+      }, 1000);
     }
   }
 
-  function drawBird() {
-    ctx.save();
-    ctx.translate(bird.x, bird.y);
-    ctx.rotate(Math.max(Math.min(bird.rotation, 0.45), -0.75));
-    ctx.fillStyle = '#ffe56c';
-    ctx.beginPath();
-    ctx.arc(0, 0, bird.radius, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.fillStyle = '#f9c23c';
-    ctx.beginPath();
-    ctx.ellipse(-bird.radius * 0.6, 0, bird.radius * 0.65, bird.radius * 0.5, 0, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.fillStyle = '#0c1324';
-    ctx.beginPath();
-    ctx.arc(bird.radius * 0.4, -bird.radius * 0.2, bird.radius * 0.25, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.fillStyle = '#ff9a3c';
-    ctx.beginPath();
-    ctx.moveTo(bird.radius, 0);
-    ctx.lineTo(bird.radius + 12, -4);
-    ctx.lineTo(bird.radius + 12, 4);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.restore();
+  function updateTurnPanel() {
+    const players = ['dawn', 'dusk'];
+    players.forEach((player) => {
+      const card = playerCards[player];
+      const badge = turnBadges[player];
+      card.classList.remove('player-card--active', 'player-card--alert');
+      if (gameState === 'ended') {
+        if (winner === player) {
+          badge.textContent = 'Победа';
+        } else if (winner === null) {
+          badge.textContent = 'Перемирие';
+        } else {
+          badge.textContent = 'Поражение';
+        }
+        return;
+      }
+      if (currentPlayer === player) {
+        badge.textContent = 'Ход';
+        card.classList.add('player-card--active');
+      } else {
+        badge.textContent = 'Ожидает';
+      }
+      if (isCommanderInCheck(board, player)) {
+        card.classList.add('player-card--alert');
+        if (currentPlayer === player) {
+          badge.textContent = 'Под ударом';
+        }
+      }
+    });
   }
 
-  function drawOverlay() {
-    let title = '';
-    let subtitle = '';
-
-    if (state.mode === 'ready') {
-      title = 'Готовы к полёту?';
-      subtitle = 'Нажмите «Старт» или пробел, чтобы начать.';
-    } else if (state.mode === 'paused') {
-      title = 'Пауза';
-      subtitle = 'Нажмите «Продолжить» или пробел, чтобы вернуться в полёт.';
-    } else if (state.mode === 'gameover') {
-      title = 'Промах!';
-      subtitle = `Ваш счёт: ${state.score}. Попробуйте снова.`;
-    }
-
-    if (!title) return;
-
-    ctx.save();
-    ctx.fillStyle = 'rgba(5, 9, 18, 0.65)';
-    ctx.fillRect(40, canvas.height * 0.32, canvas.width - 80, 140);
-
-    ctx.textAlign = 'center';
-    ctx.fillStyle = '#ffe56c';
-    ctx.font = '700 32px "Segoe UI", sans-serif';
-    ctx.fillText(title, canvas.width / 2, canvas.height * 0.4);
-
-    ctx.fillStyle = '#d2dbf5';
-    ctx.font = '400 18px "Segoe UI", sans-serif';
-    ctx.fillText(subtitle, canvas.width / 2, canvas.height * 0.47);
-    ctx.restore();
+  function updateCaptured() {
+    const order = ['commander', 'sentinel', 'strider', 'lancer', 'squire'];
+    ['dawn', 'dusk'].forEach((player) => {
+      const container = capturedEls[player];
+      container.innerHTML = '';
+      const counts = capturedPieces[player].reduce((acc, type) => {
+        acc[type] = (acc[type] || 0) + 1;
+        return acc;
+      }, {});
+      const entries = order.filter((type) => counts[type]);
+      if (entries.length === 0) {
+        const empty = document.createElement('span');
+        empty.className = 'captured__empty';
+        empty.textContent = 'Пока без трофеев';
+        container.appendChild(empty);
+        return;
+      }
+      entries.forEach((type) => {
+        const span = document.createElement('span');
+        const glyph = document.createElement('span');
+        glyph.setAttribute('aria-hidden', 'true');
+        glyph.textContent = PIECES[type].glyph[otherPlayer(player)];
+        const count = document.createElement('strong');
+        count.textContent = `${counts[type]}×`;
+        const label = document.createTextNode(` ${PIECES[type].name}`);
+        span.append(glyph, count, label);
+        container.appendChild(span);
+      });
+    });
   }
 
-  function drawScore() {
-    ctx.save();
-    ctx.textAlign = 'left';
-    ctx.font = '700 24px "Segoe UI", sans-serif';
-    ctx.fillStyle = 'rgba(255, 229, 108, 0.95)';
-    ctx.fillText(`Счёт: ${state.score}`, 20, 36);
-    ctx.fillText(`Рекорд: ${state.best}`, 20, 66);
-    ctx.restore();
-  }
-
-  function draw() {
-    drawBackground();
-    drawPipes();
-    drawGround();
-    drawBird();
-    drawScore();
-    drawOverlay();
-  }
-
-  function loop(timestamp) {
-    const delta = Math.min((timestamp - state.lastTime) / 1000, 0.05);
-    state.lastTime = timestamp;
-
-    if (state.mode === 'running') {
-      updateGame(delta);
-    }
-
-    draw();
-    animationId = requestAnimationFrame(loop);
-  }
-
-  function handleFlapTrigger(event) {
-    if (event) {
-      event.preventDefault();
-    }
-
-    if (state.mode === 'ready' || state.mode === 'gameover') {
-      beginGame();
-    } else if (state.mode === 'running') {
-      flap();
-    } else if (state.mode === 'paused') {
-      togglePause();
+  function renderMoveLog() {
+    moveLogEl.innerHTML = '';
+    for (let i = 0; i < moveHistory.length; i += 2) {
+      const entry = document.createElement('li');
+      entry.className = 'move-log__entry';
+      const turnNumber = Math.floor(i / 2) + 1;
+      const turnLabel = document.createElement('span');
+      turnLabel.className = 'move-log__turn';
+      turnLabel.textContent = `${turnNumber}`;
+      const row = document.createElement('div');
+      row.className = 'move-log__row';
+      row.appendChild(createMoveLogCell(moveHistory[i]));
+      row.appendChild(createMoveLogCell(moveHistory[i + 1]));
+      entry.append(turnLabel, row);
+      moveLogEl.appendChild(entry);
     }
   }
 
-  ui.start.addEventListener('click', () => {
-    beginGame();
-  });
-
-  ui.pause.addEventListener('click', () => {
-    togglePause();
-  });
-
-  ui.restart.addEventListener('click', () => {
-    beginGame();
-  });
-
-  canvas.addEventListener('pointerdown', handleFlapTrigger);
-  window.addEventListener('keydown', (event) => {
-    if (event.code === 'Space' || event.code === 'ArrowUp') {
-      handleFlapTrigger(event);
-    } else if (event.code === 'KeyP') {
-      event.preventDefault();
-      togglePause();
-    } else if (event.code === 'KeyR' && state.mode !== 'ready') {
-      event.preventDefault();
-      beginGame();
+  function createMoveLogCell(entry) {
+    const cell = document.createElement('div');
+    cell.className = 'move-log__cell';
+    if (!entry) {
+      cell.classList.add('move-log__cell--empty');
+      cell.textContent = '…';
+      return cell;
     }
-  });
-
-  window.addEventListener('touchstart', (event) => {
-    handleFlapTrigger(event);
-  }, { passive: false });
-
-  document.addEventListener('visibilitychange', () => {
-    if (document.hidden && state.mode === 'running') {
-      togglePause();
+    const playerLabel = document.createElement('span');
+    playerLabel.className = 'move-log__player';
+    playerLabel.textContent = PLAYERS[entry.player].name;
+    const notation = document.createElement('span');
+    notation.className = 'move-log__notation';
+    notation.textContent = `${PIECES[entry.pieceType].glyph[entry.player]} ${entry.notation}`;
+    const detail = document.createElement('p');
+    detail.className = 'move-log__detail';
+    const flags = [];
+    if (entry.capture) {
+      flags.push('взято');
     }
-  });
-
-  function cancelAnimation() {
-    if (animationId !== null) {
-      cancelAnimationFrame(animationId);
-      animationId = null;
+    if (entry.promotion) {
+      flags.push(`повышение → ${PIECES[entry.promotion].name}`);
     }
+    if (entry.checkmate) {
+      flags.push('мат');
+    } else if (entry.check) {
+      flags.push('шах');
+    }
+    if (entry.stalemate) {
+      flags.push('пат');
+    }
+    detail.textContent = flags.length ? flags.join(' · ') : 'манёвр';
+    cell.append(playerLabel, notation, detail);
+    return cell;
   }
 
-  window.addEventListener('beforeunload', cancelAnimation);
+  function updatePieceFocus(piece, row, col) {
+    focusEls.traits.innerHTML = '';
+    focusEls.stats.innerHTML = '';
+    if (!piece) {
+      focusEls.card.classList.add('focus-card--empty');
+      focusEls.glyph.textContent = '☆';
+      focusEls.name.textContent = 'Выберите фигуру, чтобы узнать её сильные стороны';
+      focusEls.role.textContent = '';
+      focusEls.summary.textContent = '';
+      focusEls.movement.textContent = '';
+      focusEls.position.textContent = '';
+      focusEls.status.textContent = '';
+      focusEls.promotion.textContent = '';
+      const placeholder = document.createElement('li');
+      placeholder.className = 'tag-list__placeholder';
+      placeholder.textContent = 'Тактическое досье появится здесь';
+      focusEls.traits.appendChild(placeholder);
+      return;
+    }
 
-  function init() {
-    resetEntities();
-    state.mode = 'ready';
-    applyUiState();
-    updateScoreboard();
-    state.lastTime = performance.now();
-    animationId = requestAnimationFrame(loop);
+    const def = PIECES[piece.type];
+    focusEls.card.classList.remove('focus-card--empty');
+    focusEls.glyph.textContent = def.glyph[piece.owner];
+    focusEls.name.textContent = `${def.name} — ${PLAYERS[piece.owner].name}`;
+    focusEls.role.textContent = def.role;
+    focusEls.summary.textContent = def.description;
+    focusEls.movement.textContent = def.movement;
+    focusEls.position.textContent = `Позиция: ${toNotation(row, col)}`;
+    focusEls.status.textContent = piece.moved ? 'Уже участвовал в манёврах.' : 'Пока не двигался.';
+    if (piece.promotedFrom && piece.promotedFrom !== piece.type) {
+      focusEls.promotion.textContent = `Повышен из ${PIECES[piece.promotedFrom].name}.`;
+    } else {
+      focusEls.promotion.textContent = '';
+    }
+
+    def.traits.forEach((trait) => {
+      const li = document.createElement('li');
+      li.textContent = trait;
+      focusEls.traits.appendChild(li);
+    });
+
+    Object.entries(def.stats).forEach(([key, value]) => {
+      const dt = document.createElement('dt');
+      dt.textContent = key;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      focusEls.stats.append(dt, dd);
+    });
   }
 
-  init();
+  function populateCodex() {
+    codexEl.innerHTML = '';
+    Object.entries(PIECES).forEach(([type, def]) => {
+      const card = document.createElement('article');
+      card.className = `codex-card codex-card--${type}`;
+      const header = document.createElement('div');
+      header.className = 'codex-card__header';
+      const glyph = document.createElement('span');
+      glyph.className = 'codex-card__glyph';
+      glyph.textContent = def.glyph.dawn;
+      const titleWrap = document.createElement('div');
+      const title = document.createElement('h3');
+      title.className = 'codex-card__title';
+      title.textContent = def.name;
+      const role = document.createElement('p');
+      role.className = 'codex-card__role';
+      role.textContent = def.role;
+      titleWrap.append(title, role);
+      header.append(glyph, titleWrap);
+      const desc = document.createElement('p');
+      desc.className = 'codex-card__text';
+      desc.textContent = def.description;
+      const move = document.createElement('p');
+      move.className = 'codex-card__text';
+      move.textContent = def.movement;
+      const traits = document.createElement('ul');
+      traits.className = 'tag-list';
+      def.traits.forEach((trait) => {
+        const li = document.createElement('li');
+        li.textContent = trait;
+        traits.appendChild(li);
+      });
+      const stats = document.createElement('dl');
+      stats.className = 'stat-list';
+      Object.entries(def.stats).forEach(([key, value]) => {
+        const dt = document.createElement('dt');
+        dt.textContent = key;
+        const dd = document.createElement('dd');
+        dd.textContent = value;
+        stats.append(dt, dd);
+      });
+      card.append(header, desc, move, traits, stats);
+      codexEl.appendChild(card);
+    });
+  }
+
+  function toNotation(row, col) {
+    const letter = COLUMN_LETTERS[col] || '?';
+    const number = ROW_NUMBERS[row] || row + 1;
+    return `${letter}${number}`;
+  }
+
+  function otherPlayer(player) {
+    return player === 'dawn' ? 'dusk' : 'dawn';
+  }
+
+  function createInitialBoard() {
+    const backline = ['sentinel', 'lancer', 'commander', 'strider', 'lancer', 'sentinel'];
+    const boardState = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+    for (let col = 0; col < BOARD_SIZE; col += 1) {
+      boardState[0][col] = createPiece(backline[col], 'dusk');
+      boardState[1][col] = createPiece('squire', 'dusk');
+      boardState[BOARD_SIZE - 2][col] = createPiece('squire', 'dawn');
+      boardState[BOARD_SIZE - 1][col] = createPiece(backline[col], 'dawn');
+    }
+    return boardState;
+  }
+
+  function createPiece(type, owner) {
+    return { type, owner, moved: false };
+  }
+
+  function cloneBoard(boardState) {
+    return boardState.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
+  }
+
+  function applyMoveOnBoard(boardState, fromRow, fromCol, toRow, toCol, options = {}) {
+    const clone = cloneBoard(boardState);
+    const piece = clone[fromRow][fromCol];
+    clone[fromRow][fromCol] = null;
+    if (!piece) {
+      return clone;
+    }
+    const movedPiece = { ...piece, moved: true };
+    if (options.promotion) {
+      movedPiece.promotedFrom = movedPiece.promotedFrom || movedPiece.type;
+      movedPiece.type = options.promotion;
+    }
+    clone[toRow][toCol] = movedPiece;
+    return clone;
+  }
+
+  function getLegalMoves(row, col) {
+    return getLegalMovesForBoard(board, row, col, currentPlayer);
+  }
+
+  function getLegalMovesForBoard(boardState, row, col, player) {
+    const piece = boardState[row][col];
+    if (!piece || piece.owner !== player) {
+      return [];
+    }
+    const pseudoMoves = generatePseudoMoves(boardState, row, col, piece, 'move');
+    const legal = [];
+    for (const move of pseudoMoves) {
+      const target = boardState[move.row][move.col];
+      if (target && target.owner === player) {
+        continue;
+      }
+      const promotionType = piece.type === 'squire' && move.row === promotionRowFor(player) ? 'strider' : null;
+      const boardAfter = applyMoveOnBoard(boardState, row, col, move.row, move.col, { promotion: promotionType });
+      const commander = findCommander(boardAfter, player);
+      if (!commander) {
+        continue;
+      }
+      if (isSquareUnderAttack(boardAfter, commander.row, commander.col, otherPlayer(player))) {
+        continue;
+      }
+      legal.push({
+        row: move.row,
+        col: move.col,
+        capture: Boolean(target),
+        promotion: promotionType
+      });
+    }
+    return legal;
+  }
+
+  function hasLegalMoves(boardState, player) {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const piece = boardState[row][col];
+        if (piece && piece.owner === player) {
+          const moves = getLegalMovesForBoard(boardState, row, col, player);
+          if (moves.length > 0) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  function promotionRowFor(player) {
+    return player === 'dawn' ? 0 : BOARD_SIZE - 1;
+  }
+
+  function isCommanderInCheck(boardState, player) {
+    const commander = findCommander(boardState, player);
+    if (!commander) {
+      return false;
+    }
+    return isSquareUnderAttack(boardState, commander.row, commander.col, otherPlayer(player));
+  }
+
+  function findCommander(boardState, player) {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const piece = boardState[row][col];
+        if (piece && piece.owner === player && piece.type === 'commander') {
+          return { row, col };
+        }
+      }
+    }
+    return null;
+  }
+
+  function isSquareUnderAttack(boardState, targetRow, targetCol, attacker) {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      for (let col = 0; col < BOARD_SIZE; col += 1) {
+        const piece = boardState[row][col];
+        if (!piece || piece.owner !== attacker) {
+          continue;
+        }
+        const threats = generatePseudoMoves(boardState, row, col, piece, 'threat');
+        if (threats.some((move) => move.row === targetRow && move.col === targetCol)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function generatePseudoMoves(boardState, row, col, piece, purpose) {
+    const moves = [];
+    const owner = piece.owner;
+    const isThreat = purpose === 'threat';
+
+    const pushSliding = (directions) => {
+      directions.forEach(([dr, dc]) => {
+        let r = row + dr;
+        let c = col + dc;
+        while (isInside(r, c)) {
+          const occupant = boardState[r][c];
+          if (!occupant) {
+            moves.push({ row: r, col: c });
+          } else {
+            if (occupant.owner !== owner) {
+              moves.push({ row: r, col: c });
+            }
+            break;
+          }
+          r += dr;
+          c += dc;
+        }
+      });
+    };
+
+    switch (piece.type) {
+      case 'commander': {
+        for (let dr = -1; dr <= 1; dr += 1) {
+          for (let dc = -1; dc <= 1; dc += 1) {
+            if (dr === 0 && dc === 0) continue;
+            const r = row + dr;
+            const c = col + dc;
+            if (!isInside(r, c)) continue;
+            const occupant = boardState[r][c];
+            if (occupant && occupant.owner === owner) continue;
+            moves.push({ row: r, col: c });
+          }
+        }
+        break;
+      }
+      case 'sentinel': {
+        pushSliding([
+          [1, 0],
+          [-1, 0],
+          [0, 1],
+          [0, -1]
+        ]);
+        break;
+      }
+      case 'strider': {
+        pushSliding([
+          [1, 1],
+          [1, -1],
+          [-1, 1],
+          [-1, -1]
+        ]);
+        break;
+      }
+      case 'lancer': {
+        const jumps = [
+          [2, 1], [2, -1],
+          [-2, 1], [-2, -1],
+          [1, 2], [1, -2],
+          [-1, 2], [-1, -2]
+        ];
+        jumps.forEach(([dr, dc]) => {
+          const r = row + dr;
+          const c = col + dc;
+          if (!isInside(r, c)) return;
+          const occupant = boardState[r][c];
+          if (occupant && occupant.owner === owner) return;
+          moves.push({ row: r, col: c });
+        });
+        break;
+      }
+      case 'squire': {
+        const dir = directionByPlayer[owner];
+        const forwardRow = row + dir;
+        if (purpose === 'move') {
+          if (isInside(forwardRow, col) && !boardState[forwardRow][col]) {
+            moves.push({ row: forwardRow, col });
+            const doubleRow = forwardRow + dir;
+            if (!piece.moved && isInside(doubleRow, col) && !boardState[doubleRow][col]) {
+              moves.push({ row: doubleRow, col });
+            }
+          }
+          [-1, 1].forEach((dc) => {
+            const r = row + dir;
+            const c = col + dc;
+            if (!isInside(r, c)) return;
+            const occupant = boardState[r][c];
+            if (occupant && occupant.owner !== owner) {
+              moves.push({ row: r, col: c });
+            }
+          });
+        } else {
+          [-1, 1].forEach((dc) => {
+            const r = row + dir;
+            const c = col + dc;
+            if (isInside(r, c)) {
+              moves.push({ row: r, col: c });
+            }
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    if (isThreat && piece.type !== 'squire') {
+      // For threats we should not include squares beyond allied pieces; already handled.
+      return moves;
+    }
+
+    return moves;
+  }
+
+  function isInside(row, col) {
+    return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
+  }
+
+  start();
 })();

--- a/style.css
+++ b/style.css
@@ -1,113 +1,733 @@
-* {
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at 20% 20%, #182347 0%, #0a0f1f 55%, #050812 100%);
+  --panel-bg: rgba(12, 22, 45, 0.78);
+  --panel-border: rgba(120, 167, 255, 0.2);
+  --text-primary: #dde7ff;
+  --text-muted: #94a3c7;
+  --accent-dawn: #f6d47f;
+  --accent-dusk: #7aa5ff;
+  --accent-neutral: rgba(255, 255, 255, 0.08);
+  --cell-light: linear-gradient(145deg, rgba(95, 130, 197, 0.35), rgba(26, 42, 74, 0.7));
+  --cell-dark: linear-gradient(145deg, rgba(18, 30, 56, 0.9), rgba(11, 19, 33, 0.95));
+  --highlight-move: rgba(134, 215, 255, 0.35);
+  --highlight-capture: rgba(255, 126, 158, 0.42);
+  --highlight-selected: rgba(255, 255, 255, 0.65);
+  --highlight-check: rgba(255, 182, 92, 0.55);
+  --focus-shadow: 0 18px 40px rgba(5, 8, 20, 0.55);
+  font-family: "Segoe UI", "Roboto", "Nunito", sans-serif;
+}
+
+*, *::before, *::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
-  color: #f5f7ff;
-  background: radial-gradient(circle at top, #182742 0%, #0c1324 55%, #05070f 100%);
+  background: var(--bg);
+  color: var(--text-primary);
+}
+
+button {
+  font: inherit;
+}
+
+.shell {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 40px);
   display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 24px;
+  flex-direction: column;
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(16px, 4vw, 40px);
+  background: linear-gradient(145deg, rgba(35, 58, 112, 0.38), rgba(9, 15, 28, 0.85));
+  border: 1px solid rgba(140, 180, 255, 0.2);
+  border-radius: 28px;
+  padding: clamp(18px, 4vw, 32px);
+  box-shadow: 0 25px 60px rgba(4, 9, 28, 0.5);
+}
+
+.hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero__overtitle {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: rgba(198, 212, 255, 0.7);
+  margin: 0;
+}
+
+.hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 38ch;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.hero__button {
+  align-self: stretch;
+  padding: 14px 24px;
+  border-radius: 16px;
+  border: none;
+  color: #02030a;
+  font-weight: 700;
+  background: linear-gradient(135deg, #f6d47f, #ffd27a 30%, #ffb87d 100%);
+  box-shadow: 0 12px 30px rgba(255, 193, 107, 0.35);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.hero__button:hover,
+.hero__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(255, 193, 107, 0.4);
 }
 
 .layout {
-  width: min(480px, 100%);
   display: grid;
-  gap: 16px;
-  text-align: center;
+  grid-template-columns: minmax(360px, 1.15fr) minmax(260px, 0.85fr);
+  gap: clamp(18px, 4vw, 32px);
+  align-items: start;
 }
 
-.header h1 {
+.board-area {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.board-frame {
+  position: relative;
+  padding: clamp(12px, 3vw, 18px);
+  border-radius: 28px;
+  background: linear-gradient(150deg, rgba(48, 78, 143, 0.45), rgba(13, 21, 38, 0.9));
+  border: 1px solid rgba(142, 186, 255, 0.18);
+  box-shadow: 0 20px 55px rgba(6, 8, 20, 0.6);
+}
+
+.board {
+  --board-size: 6;
+  display: grid;
+  grid-template-columns: repeat(var(--board-size), minmax(52px, 1fr));
+  gap: clamp(6px, 1.4vw, 10px);
+}
+
+.cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1 / 1;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  background: var(--cell-light);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cell--dark {
+  background: var(--cell-dark);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.cell:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(6, 10, 26, 0.4);
+}
+
+.cell:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.cell::after {
+  content: "";
+  position: absolute;
+  inset: 10%;
+  border-radius: 16px;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.15s ease, transform 0.2s ease;
+}
+
+.cell--selected::after {
+  background: var(--highlight-selected);
+  opacity: 0.4;
+  transform: scale(1);
+}
+
+.cell--move::after {
+  background: var(--highlight-move);
+  opacity: 0.65;
+  transform: scale(1);
+}
+
+.cell--capture::after {
+  background: var(--highlight-capture);
+  opacity: 0.8;
+  transform: scale(1);
+}
+
+.cell--alert::after {
+  background: var(--highlight-check);
+  opacity: 0.9;
+  transform: scale(1);
+  box-shadow: 0 0 18px rgba(255, 182, 92, 0.8);
+}
+
+.piece {
+  width: 72%;
+  height: 72%;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  backdrop-filter: blur(4px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22), 0 10px 25px rgba(0, 0, 0, 0.45);
+  transition: transform 0.18s ease;
+}
+
+.piece--dawn {
+  background: radial-gradient(circle at 30% 30%, rgba(255, 240, 200, 0.92), rgba(246, 212, 127, 0.95));
+  color: #331b05;
+}
+
+.piece--dusk {
+  background: radial-gradient(circle at 30% 30%, rgba(220, 234, 255, 0.92), rgba(122, 165, 255, 0.96));
+  color: #081231;
+}
+
+.piece__glyph {
+  text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+}
+
+.status {
+  display: grid;
+  gap: 6px;
+  padding: 16px 20px;
+  background: linear-gradient(150deg, rgba(18, 28, 52, 0.85), rgba(10, 16, 31, 0.9));
+  border-radius: 18px;
+  border: 1px solid rgba(120, 167, 255, 0.2);
+  box-shadow: var(--focus-shadow);
+}
+
+.status p {
   margin: 0;
+  font-size: 0.95rem;
+}
+
+.status p:first-child {
+  font-weight: 600;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 26px;
+  border: 1px solid var(--panel-border);
+  padding: clamp(16px, 3vw, 24px);
+  display: grid;
+  gap: clamp(14px, 3vw, 20px);
+  box-shadow: var(--focus-shadow);
+}
+
+.panel__title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel__title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.panel__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.player-card {
+  position: relative;
+  background: linear-gradient(155deg, rgba(24, 38, 66, 0.9), rgba(9, 14, 24, 0.9));
+  border-radius: 22px;
+  padding: 16px;
+  border: 1px solid rgba(110, 160, 255, 0.18);
+  display: grid;
+  gap: 12px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.player-card[data-player="dawn"] .player-card__crest {
+  background: radial-gradient(circle, rgba(246, 212, 127, 0.8), rgba(246, 212, 127, 0));
+}
+
+.player-card[data-player="dusk"] .player-card__crest {
+  background: radial-gradient(circle, rgba(122, 165, 255, 0.85), rgba(122, 165, 255, 0));
+}
+
+.player-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.player-card__crest {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.player-card__tagline {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.player-card__turn {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.player-card__body {
+  display: grid;
+  gap: 8px;
+}
+
+.player-card__label {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(201, 211, 245, 0.7);
+}
+
+.captured {
+  min-height: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.captured span {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.captured span strong {
+  font-weight: 600;
+  color: #fff2c2;
+}
+
+.captured span span {
+  font-size: 1.1rem;
+}
+
+.captured__empty {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.player-card--active {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 38px rgba(10, 16, 34, 0.55);
+}
+
+.player-card--active .player-card__turn {
+  background: linear-gradient(135deg, rgba(246, 212, 127, 0.9), rgba(255, 184, 125, 0.9));
+  color: #1f1304;
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.player-card--alert {
+  box-shadow: 0 22px 42px rgba(255, 136, 90, 0.35);
+}
+
+.player-card--alert .player-card__turn {
+  background: linear-gradient(135deg, rgba(255, 145, 98, 0.95), rgba(255, 99, 132, 0.85));
+  color: #2b0508;
+}
+
+.focus-card {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 16px;
+  align-items: start;
+  background: linear-gradient(155deg, rgba(19, 32, 58, 0.9), rgba(8, 12, 25, 0.95));
+  border-radius: 22px;
+  padding: 18px;
+  border: 1px solid rgba(130, 175, 255, 0.2);
+  position: relative;
+}
+
+.focus-card__glyph {
+  width: 80px;
+  height: 80px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 2.4rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.focus-card__text {
+  display: grid;
+  gap: 8px;
+}
+
+.focus-card__text h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.focus-card__text p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.focus-card__movement {
+  color: #ffe6a8;
+}
+
+.focus-card__status {
+  color: #9bd0ff;
+}
+
+.focus-card__promotion {
+  color: #ffd4ba;
+}
+
+.focus-card__traits,
+.focus-card__stats {
+  grid-column: 1 / -1;
+}
+
+.focus-card__traits h4,
+.focus-card__stats h4 {
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(206, 220, 255, 0.7);
+}
+
+.tag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-list li {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.tag-list__placeholder {
+  opacity: 0.5;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.stat-list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px 12px;
+}
+
+.stat-list dt {
+  font-size: 0.78rem;
+  color: rgba(206, 220, 255, 0.7);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.subtitle {
-  margin: 8px 0 0;
-  color: #aab6d6;
+.stat-list dd {
+  margin: 0;
   font-size: 0.95rem;
+  font-weight: 600;
 }
 
-.hud {
-  display: flex;
-  justify-content: space-between;
+.focus-card--empty {
+  background: linear-gradient(155deg, rgba(22, 33, 57, 0.7), rgba(7, 11, 24, 0.85));
+}
+
+.focus-card--empty .focus-card__glyph {
+  opacity: 0.4;
+}
+
+.codex {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.codex-card {
+  background: linear-gradient(155deg, rgba(27, 42, 74, 0.85), rgba(12, 20, 38, 0.9));
+  border-radius: 20px;
+  padding: 16px;
+  border: 1px solid rgba(128, 170, 255, 0.18);
+  display: grid;
+  gap: 12px;
+}
+
+.codex-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.scoreboard {
+.codex-card__glyph {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
   display: flex;
-  gap: 16px;
-  font-size: 1.1rem;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
-.scoreboard strong {
-  color: #ffe56c;
+.codex-card__title {
+  margin: 0;
+  font-size: 1rem;
 }
 
-.controls {
+.codex-card__role {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.codex-card__text {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.rules {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.log {
+  gap: 18px;
+}
+
+.move-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: clamp(220px, 32vh, 320px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.move-log::-webkit-scrollbar {
+  width: 6px;
+}
+
+.move-log::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
+.move-log__entry {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  align-items: start;
+  gap: 12px;
+  background: rgba(13, 21, 38, 0.75);
+  border-radius: 16px;
+  padding: 10px 14px;
+  border: 1px solid rgba(120, 167, 255, 0.18);
+}
+
+.move-log__turn {
+  font-weight: 700;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.move-log__row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
   gap: 8px;
 }
 
-button {
-  padding: 8px 16px;
-  border: none;
-  border-radius: 999px;
+.move-log__cell {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: grid;
+  gap: 4px;
+}
+
+.move-log__cell--empty {
+  opacity: 0.4;
+  text-align: center;
+  padding: 12px;
+}
+
+.move-log__player {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(203, 216, 255, 0.6);
+}
+
+.move-log__notation {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #0c1324;
-  background: linear-gradient(135deg, #ffe56c, #ffb347);
-  cursor: pointer;
-  transition: transform 0.15s ease, filter 0.2s ease;
 }
 
-button[disabled] {
-  cursor: not-allowed;
-  opacity: 0.55;
-  transform: none;
-}
-
-button:not([disabled]):hover {
-  filter: brightness(1.05);
-}
-
-button:not([disabled]):active {
-  transform: scale(0.96);
-}
-
-#game {
-  width: 100%;
-  height: auto;
-  border-radius: 24px;
-  background: linear-gradient(180deg, #0b1020 0%, #0c1f35 45%, #13294c 100%);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.6);
-}
-
-.hint {
+.move-log__detail {
   margin: 0;
-  font-size: 0.9rem;
-  color: #94a4cf;
+  font-size: 0.8rem;
+  color: var(--text-muted);
 }
 
-@media (max-width: 520px) {
+.endgame {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  background: rgba(5, 8, 20, 0.92);
+  border-radius: inherit;
+  border: 1px solid rgba(246, 212, 127, 0.3);
+  backdrop-filter: blur(4px);
+  gap: 12px;
+}
+
+.endgame h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.endgame p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.endgame__button {
+  padding: 12px 24px;
+  border-radius: 14px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(135deg, #7aa5ff, #a3c2ff);
+  color: #06112b;
+  box-shadow: 0 12px 28px rgba(122, 165, 255, 0.35);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1050px) {
   .layout {
-    gap: 12px;
+    grid-template-columns: 1fr;
   }
 
-  .hud {
+  .hero {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .controls {
-    justify-content: center;
+  .hero__button {
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .board {
+    grid-template-columns: repeat(var(--board-size), minmax(40px, 1fr));
+  }
+
+  .move-log__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 540px) {
+  .focus-card {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .focus-card__glyph {
+    justify-self: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous flappy prototype with the two-player "Астральный двор" board game experience
- implement complete move validation including captures, шах/мат detection, и продвижение рекрутов
- craft an expanded HUD with move log, captured trophies, and interactive dossier and codex panels

## Testing
- not run (front-end experience)

------
https://chatgpt.com/codex/tasks/task_e_6901f8d2760883209e7e081efe175f94