### PR TITLE
Исправить запуск новой партии и адаптивность интерфейса

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@
 
   const PLAYERS = {
     dawn: {
-      name: 'Орден Рассвеа',
+      name: 'Орден Рассвета',
       motto: 'Инициатива света',
       color: '#f6d47f'
     },
@@ -65,44 +65,21 @@
     }
   };
 
-  const boardEl = document.getElementById('board');
-  const statusPrimaryEl = document.getElementById('status-primary');
-  const statusSecondaryEl = document.getElementById('status-secondary');
-  const moveLogEl = document.getElementById('move-log');
-  const codexEl = document.getElementById('codex');
-  const newGameButton = document.getElementById('new-game');
-  const playAgainButton = document.getElementById('play-again');
-  const liveRegion = document.getElementById('live-region');
-  const endgameEl = document.getElementById('endgame');
-  const endgameTitleEl = document.getElementById('endgame-title');
-  const endgameSubtitleEl = document.getElementById('endgame-subtitle');
-
-  const playerCards = {
-    dawn: document.querySelector('.player-card[data-player="dawn"]'),
-    dusk: document.querySelector('.player-card[data-player="dusk"]')
-  };
-  const turnBadges = {
-    dawn: document.getElementById('turn-dawn'),
-    dusk: document.getElementById('turn-dusk')
-  };
-  const capturedEls = {
-    dawn: document.getElementById('captured-dawn'),
-    dusk: document.getElementById('captured-dusk')
-  };
-
-  const focusEls = {
-    card: document.getElementById('piece-focus'),
-    glyph: document.getElementById('focus-glyph'),
-    name: document.getElementById('focus-name'),
-    role: document.getElementById('focus-role'),
-    summary: document.getElementById('focus-summary'),
-    movement: document.getElementById('focus-movement'),
-    position: document.getElementById('focus-position'),
-    status: document.getElementById('focus-status'),
-    promotion: document.getElementById('focus-promotion'),
-    traits: document.getElementById('focus-traits'),
-    stats: document.getElementById('focus-stats')
-  };
+  let boardEl;
+  let statusPrimaryEl;
+  let statusSecondaryEl;
+  let moveLogEl;
+  let codexEl;
+  let newGameButton;
+  let playAgainButton;
+  let liveRegion;
+  let endgameEl;
+  let endgameTitleEl;
+  let endgameSubtitleEl;
+  let playerCards;
+  let turnBadges;
+  let capturedEls;
+  let focusEls;
 
   let board = [];
   let cellElements = [];
@@ -115,13 +92,64 @@
   let gameState = 'idle';
   let winner = null;
 
-  newGameButton.addEventListener('click', startNewGame);
-  playAgainButton.addEventListener('click', startNewGame);
+  function initialize() {
+    boardEl = document.getElementById('board');
+    statusPrimaryEl = document.getElementById('status-primary');
+    statusSecondaryEl = document.getElementById('status-secondary');
+    moveLogEl = document.getElementById('move-log');
+    codexEl = document.getElementById('codex');
+    newGameButton = document.getElementById('new-game');
+    playAgainButton = document.getElementById('play-again');
+    liveRegion = document.getElementById('live-region');
+    endgameEl = document.getElementById('endgame');
+    endgameTitleEl = document.getElementById('endgame-title');
+    endgameSubtitleEl = document.getElementById('endgame-subtitle');
 
-  function start() {
+    playerCards = {
+      dawn: document.querySelector('.player-card[data-player="dawn"]'),
+      dusk: document.querySelector('.player-card[data-player="dusk"]')
+    };
+    turnBadges = {
+      dawn: document.getElementById('turn-dawn'),
+      dusk: document.getElementById('turn-dusk')
+    };
+    capturedEls = {
+      dawn: document.getElementById('captured-dawn'),
+      dusk: document.getElementById('captured-dusk')
+    };
+
+    focusEls = {
+      card: document.getElementById('piece-focus'),
+      glyph: document.getElementById('focus-glyph'),
+      name: document.getElementById('focus-name'),
+      role: document.getElementById('focus-role'),
+      summary: document.getElementById('focus-summary'),
+      movement: document.getElementById('focus-movement'),
+      position: document.getElementById('focus-position'),
+      status: document.getElementById('focus-status'),
+      promotion: document.getElementById('focus-promotion'),
+      traits: document.getElementById('focus-traits'),
+      stats: document.getElementById('focus-stats')
+    };
+
+    if (!boardEl) {
+      return;
+    }
+
+    newGameButton?.addEventListener('click', handleNewGameRequest);
+    playAgainButton?.addEventListener('click', handleNewGameRequest);
+
     buildBoardSkeleton();
     populateCodex();
     startNewGame();
+  }
+
+  function handleNewGameRequest(event) {
+    event?.preventDefault();
+    startNewGame();
+    if (event?.currentTarget instanceof HTMLElement) {
+      event.currentTarget.blur();
+    }
   }
 
   function startNewGame() {
@@ -897,5 +925,13 @@
     return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
   }
 
-  start();
+  whenReady(initialize);
+
+  function whenReady(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  }
 })();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ body {
 
 button {
   font: inherit;
+  touch-action: manipulation;
 }
 
 .shell {
@@ -112,6 +113,11 @@ button {
   display: flex;
   flex-direction: column;
   gap: clamp(18px, 3vw, 28px);
+}
+
+.hud {
+  display: grid;
+  gap: clamp(18px, 3vw, 26px);
 }
 
 .board-frame {
@@ -271,6 +277,10 @@ button {
   color: var(--text-muted);
   font-size: 0.85rem;
   line-height: 1.4;
+}
+
+.hud .panel {
+  height: 100%;
 }
 
 .player-card {
@@ -685,6 +695,11 @@ button {
   box-shadow: 0 12px 28px rgba(122, 165, 255, 0.35);
 }
 
+.endgame[hidden] {
+  display: none !important;
+  pointer-events: none;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -696,24 +711,99 @@ button {
   border: 0;
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
+  .shell {
+    padding: clamp(14px, 5vw, 32px);
+  }
+
   .layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .board-area {
+    align-items: center;
+  }
+
+  .board-frame {
+    width: min(100%, 520px);
+    margin: 0 auto;
   }
 
   .hero {
     flex-direction: column;
     align-items: stretch;
+    text-align: center;
+    gap: clamp(18px, 4vw, 32px);
+  }
+
+  .hero__text {
+    align-items: center;
+  }
+
+  .hero__subtitle {
+    max-width: 52ch;
   }
 
   .hero__button {
-    align-self: flex-start;
+    align-self: center;
+  }
+}
+
+@media (max-width: 900px) {
+  .board-frame {
+    padding: clamp(10px, 4vw, 16px);
+  }
+
+  .status {
+    padding: 14px 18px;
+  }
+
+  .panel {
+    padding: clamp(14px, 4vw, 20px);
+  }
+
+  .move-log {
+    max-height: clamp(200px, 36vh, 280px);
   }
 }
 
 @media (max-width: 720px) {
+  .shell {
+    gap: clamp(18px, 6vw, 28px);
+  }
+
+  .hero {
+    padding: clamp(16px, 6vw, 28px);
+  }
+
+  .hero__button {
+    width: 100%;
+    align-self: stretch;
+  }
+
+  .hero__subtitle {
+    max-width: unset;
+  }
+
   .board {
     grid-template-columns: repeat(var(--board-size), minmax(40px, 1fr));
+  }
+
+  .board-area {
+    align-items: stretch;
+  }
+
+  .board-frame {
+    width: min(100%, 460px);
+  }
+
+  .panel__title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .codex {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 
   .move-log__row {
@@ -722,6 +812,33 @@ button {
 }
 
 @media (max-width: 540px) {
+  .hero__overtitle {
+    letter-spacing: 0.26em;
+    font-size: 0.7rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(1.8rem, 8vw, 2.3rem);
+  }
+
+  .hero__subtitle {
+    font-size: 0.95rem;
+  }
+
+  .board {
+    grid-template-columns: repeat(var(--board-size), minmax(36px, 1fr));
+    gap: clamp(4px, 3vw, 8px);
+  }
+
+  .cell {
+    border-radius: 16px;
+  }
+
+  .piece {
+    border-radius: 16px;
+    font-size: clamp(1.5rem, 7vw, 1.9rem);
+  }
+
   .focus-card {
     grid-template-columns: 1fr;
     text-align: left;
@@ -729,5 +846,39 @@ button {
 
   .focus-card__glyph {
     justify-self: flex-start;
+  }
+
+  .panel {
+    padding: clamp(12px, 5vw, 18px);
+  }
+}
+
+@media (max-width: 420px) {
+  .hero {
+    gap: 20px;
+  }
+
+  .hero__text {
+    gap: 10px;
+  }
+
+  .board-frame {
+    border-radius: 22px;
+  }
+
+  .panel__title {
+    font-size: 1rem;
+  }
+
+  .panel__subtitle {
+    font-size: 0.82rem;
+  }
+
+  .tag-list {
+    gap: 6px;
+  }
+
+  .stat-list {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- ensure the game board initializes after DOM ready so the "Новая партия" control reliably restarts matches and fix the dawn order label
- guard the endgame overlay and restart handler to avoid blocking clicks and reset state cleanly
- refine responsive styles for mobile, including new breakpoints, button touch handling, and flexible panel layout

## Testing
- playwright scenario exercising a move followed by a restart

------
https://chatgpt.com/codex/tasks/task_e_690204e288e88320a338d9ffe8610b0f