### PR TITLE
Расширить поле и добавить энергозависимые способности

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
               <p id="focus-movement" class="focus-card__movement"></p>
               <p id="focus-position" class="focus-card__position"></p>
               <p id="focus-status" class="focus-card__status"></p>
+              <p id="focus-energy" class="focus-card__energy"></p>
               <p id="focus-promotion" class="focus-card__promotion"></p>
             </div>
             <div class="focus-card__traits">
@@ -98,6 +99,7 @@
               <h4>Параметры</h4>
               <dl id="focus-stats" class="stat-list"></dl>
             </div>
+            <div class="focus-card__abilities" id="focus-abilities"></div>
           </article>
         </section>
 

--- a/script.js
+++ b/script.js
@@ -1,12 +1,12 @@
 (function () {
-  const BOARD_SIZE = 6;
-  const COLUMN_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
-  const ROW_NUMBERS = [6, 5, 4, 3, 2, 1];
+  const BOARD_SIZE = 10;
+  const COLUMN_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
+  const ROW_NUMBERS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
   const directionByPlayer = { dawn: -1, dusk: 1 };
 
   const PLAYERS = {
     dawn: {
-      name: 'Орден Рассвеа',
+      name: 'Орден Рассвета',
       motto: 'Инициатива света',
       color: '#f6d47f'
     },
@@ -20,89 +20,192 @@
   const PIECES = {
     commander: {
       name: 'Командор',
-      glyph: { dawn: '♔', dusk: '♚' },
+      glyph: { dawn: '✶', dusk: '✹' },
       role: 'Лидер',
       description: 'Центр координации отряда. Командор обеспечивает связь и не может быть потерян.',
       movement: 'Ходит на одну клетку в любом направлении.',
       traits: ['Лидер', 'Тактическая аура'],
-      stats: { Манёвр: '★☆☆', Контроль: '★★★★★', Защита: '★★★★' }
+      stats: { Манёвр: '★☆☆', Контроль: '★★★★★', Защита: '★★★★' },
+      abilities: [
+        {
+          id: 'radiant-step',
+          name: 'Радиантный шаг',
+          cost: 4,
+          description: 'Прорыв на две клетки по любой из восьми направлений. Пути должны быть свободны.'
+        },
+        {
+          id: 'astral-swap',
+          name: 'Астральный обмен',
+          cost: 6,
+          description: 'Меняется местами с союзной фигурой в радиусе трёх клеток, мгновенно перебрасывая силы.'
+        }
+      ]
     },
     sentinel: {
       name: 'Страж',
-      glyph: { dawn: '♖', dusk: '♜' },
+      glyph: { dawn: '⬢', dusk: '⬣' },
       role: 'Линейный контроль',
       description: 'Стражи держат прямые коридоры и отрезают пути отступления.',
       movement: 'Любое количество клеток по горизонтали или вертикали без прыжков.',
       traits: ['Линии давления', 'Гарнизон'],
-      stats: { Манёвр: '★★★', Контроль: '★★★★', Сложность: '★★' }
+      stats: { Манёвр: '★★★', Контроль: '★★★★', Сложность: '★★' },
+      abilities: [
+        {
+          id: 'iron-diagonals',
+          name: 'Железные диагонали',
+          cost: 3,
+          description: 'Дает возможность сместиться по диагонали на одну или две клетки.'
+        },
+        {
+          id: 'siege-bolt',
+          name: 'Осадный импульс',
+          cost: 5,
+          description: 'Дистанционный удар по прямой до трёх клеток. Страж остаётся на месте.'
+        }
+      ]
     },
     strider: {
       name: 'Странник',
-      glyph: { dawn: '♗', dusk: '♝' },
+      glyph: { dawn: '◇', dusk: '◆' },
       role: 'Диагональный манёвр',
       description: 'Странники режут пространство по диагоналям и выстраивают дуги обхода.',
       movement: 'Любое количество клеток по диагонали без прыжков.',
       traits: ['Фланг', 'Позиционный прессинг'],
-      stats: { Манёвр: '★★★★', Контроль: '★★★', Сложность: '★★☆' }
+      stats: { Манёвр: '★★★★', Контроль: '★★★', Сложность: '★★☆' },
+      abilities: [
+        {
+          id: 'horizon-drift',
+          name: 'Горизонтальный дрейф',
+          cost: 3,
+          description: 'Однократный ход на две клетки по горизонтали, раскрывающий новые углы атаки.'
+        },
+        {
+          id: 'prism-gate',
+          name: 'Призматический портал',
+          cost: 6,
+          description: 'Телепорт на диагональ через три клетки, если цель свободна.'
+        }
+      ]
     },
     lancer: {
       name: 'Гонец',
-      glyph: { dawn: '♘', dusk: '♞' },
+      glyph: { dawn: '⚚', dusk: '⚝' },
       role: 'Манёвр через заслоны',
       description: 'Гонец прыгает дугой, прорывается через заслоны и наносит внезапные удары.',
       movement: 'Прыжок буквой «Г»: две клетки в одном направлении и одна в перпендикулярном.',
       traits: ['Скачок', 'Атака из тыла'],
-      stats: { Манёвр: '★★★★★', Контроль: '★★', Сложность: '★★★' }
+      stats: { Манёвр: '★★★★★', Контроль: '★★', Сложность: '★★★' },
+      abilities: [
+        {
+          id: 'meteor-dash',
+          name: 'Метеорный разгон',
+          cost: 3,
+          description: 'Рывок по прямой до трёх клеток с возможностью срезать врага в конце пути.'
+        },
+        {
+          id: 'storm-reversal',
+          name: 'Штормовой переворот',
+          cost: 5,
+          description: 'Прыжок к цели по ходу коня с обменом позиций, выбивая врага с ключевой клетки.'
+        }
+      ]
     },
     squire: {
       name: 'Рекрут',
-      glyph: { dawn: '♙', dusk: '♟' },
+      glyph: { dawn: '◖', dusk: '◗' },
       role: 'Линия фронта',
       description: 'Рекруты выстраивают фронт. Врага берут по диагонали и могут сделать стартовый рывок.',
       movement: 'На одну клетку вперёд (две при первом ходе). Захватывает по диагонали. На последней линии повышается до Странника.',
       traits: ['Гарнизон', 'Повышение'],
-      stats: { Манёвр: '★★', Контроль: '★★', Сложность: '★' }
+      stats: { Манёвр: '★★', Контроль: '★★', Сложность: '★' },
+      abilities: [
+        {
+          id: 'line-surge',
+          name: 'Фронтовой рывок',
+          cost: 2,
+          description: 'Повторный марш на две клетки вперёд даже после первых шагов, если путь свободен.'
+        },
+        {
+          id: 'hook-strike',
+          name: 'Крюковой удар',
+          cost: 3,
+          description: 'Лобовая атака на одну клетку вперёд, пробивая оборону противника.'
+        }
+      ]
     }
   };
 
-  const boardEl = document.getElementById('board');
-  const statusPrimaryEl = document.getElementById('status-primary');
-  const statusSecondaryEl = document.getElementById('status-secondary');
-  const moveLogEl = document.getElementById('move-log');
-  const codexEl = document.getElementById('codex');
-  const newGameButton = document.getElementById('new-game');
-  const playAgainButton = document.getElementById('play-again');
-  const liveRegion = document.getElementById('live-region');
-  const endgameEl = document.getElementById('endgame');
-  const endgameTitleEl = document.getElementById('endgame-title');
-  const endgameSubtitleEl = document.getElementById('endgame-subtitle');
-
-  const playerCards = {
-    dawn: document.querySelector('.player-card[data-player="dawn"]'),
-    dusk: document.querySelector('.player-card[data-player="dusk"]')
-  };
-  const turnBadges = {
-    dawn: document.getElementById('turn-dawn'),
-    dusk: document.getElementById('turn-dusk')
-  };
-  const capturedEls = {
-    dawn: document.getElementById('captured-dawn'),
-    dusk: document.getElementById('captured-dusk')
+  const MAX_ENERGY = 16;
+  const CAPTURE_REWARD = {
+    commander: 6,
+    sentinel: 4,
+    strider: 4,
+    lancer: 4,
+    squire: 2
   };
 
-  const focusEls = {
-    card: document.getElementById('piece-focus'),
-    glyph: document.getElementById('focus-glyph'),
-    name: document.getElementById('focus-name'),
-    role: document.getElementById('focus-role'),
-    summary: document.getElementById('focus-summary'),
-    movement: document.getElementById('focus-movement'),
-    position: document.getElementById('focus-position'),
-    status: document.getElementById('focus-status'),
-    promotion: document.getElementById('focus-promotion'),
-    traits: document.getElementById('focus-traits'),
-    stats: document.getElementById('focus-stats')
+  const ABILITY_EFFECTS = {
+    'radiant-step': {
+      generate: generateRadiantStepOptions,
+      apply: applyStandardAbilityMove
+    },
+    'astral-swap': {
+      generate: generateAstralSwapOptions,
+      apply: applyAstralSwap
+    },
+    'iron-diagonals': {
+      generate: generateIronDiagonalOptions,
+      apply: applyStandardAbilityMove
+    },
+    'siege-bolt': {
+      generate: generateSiegeBoltOptions,
+      apply: applySiegeBolt
+    },
+    'horizon-drift': {
+      generate: generateHorizonDriftOptions,
+      apply: applyStandardAbilityMove
+    },
+    'prism-gate': {
+      generate: generatePrismGateOptions,
+      apply: applyStandardAbilityMove
+    },
+    'meteor-dash': {
+      generate: generateMeteorDashOptions,
+      apply: applyStandardAbilityMove
+    },
+    'storm-reversal': {
+      generate: generateStormReversalOptions,
+      apply: applyStormReversal
+    },
+    'line-surge': {
+      generate: generateLineSurgeOptions,
+      apply: applyStandardAbilityMove
+    },
+    'hook-strike': {
+      generate: generateHookStrikeOptions,
+      apply: applyStandardAbilityMove
+    }
   };
+
+  let boardEl;
+  let boardFrame;
+  let statusPrimaryEl;
+  let statusSecondaryEl;
+  let moveLogEl;
+  let codexEl;
+  let newGameButton;
+  let playAgainButton;
+  let liveRegion;
+  let endgameEl;
+  let endgameTitleEl;
+  let endgameSubtitleEl;
+  let playerCards;
+  let turnBadges;
+  let capturedEls;
+  let focusEls;
+
+  let activeAbility = null;
+  let abilitySource = null;
 
   let board = [];
   let cellElements = [];
@@ -115,13 +218,68 @@
   let gameState = 'idle';
   let winner = null;
 
-  newGameButton.addEventListener('click', startNewGame);
-  playAgainButton.addEventListener('click', startNewGame);
+  function initialize() {
+    boardEl = document.getElementById('board');
+    boardFrame = document.querySelector('.board-frame');
+    statusPrimaryEl = document.getElementById('status-primary');
+    statusSecondaryEl = document.getElementById('status-secondary');
+    moveLogEl = document.getElementById('move-log');
+    codexEl = document.getElementById('codex');
+    newGameButton = document.getElementById('new-game');
+    playAgainButton = document.getElementById('play-again');
+    liveRegion = document.getElementById('live-region');
+    endgameEl = document.getElementById('endgame');
+    endgameTitleEl = document.getElementById('endgame-title');
+    endgameSubtitleEl = document.getElementById('endgame-subtitle');
 
-  function start() {
+    playerCards = {
+      dawn: document.querySelector('.player-card[data-player="dawn"]'),
+      dusk: document.querySelector('.player-card[data-player="dusk"]')
+    };
+    turnBadges = {
+      dawn: document.getElementById('turn-dawn'),
+      dusk: document.getElementById('turn-dusk')
+    };
+    capturedEls = {
+      dawn: document.getElementById('captured-dawn'),
+      dusk: document.getElementById('captured-dusk')
+    };
+
+    focusEls = {
+      card: document.getElementById('piece-focus'),
+      glyph: document.getElementById('focus-glyph'),
+      name: document.getElementById('focus-name'),
+      role: document.getElementById('focus-role'),
+      summary: document.getElementById('focus-summary'),
+      movement: document.getElementById('focus-movement'),
+      position: document.getElementById('focus-position'),
+      status: document.getElementById('focus-status'),
+      promotion: document.getElementById('focus-promotion'),
+      energy: document.getElementById('focus-energy'),
+      traits: document.getElementById('focus-traits'),
+      stats: document.getElementById('focus-stats'),
+      abilities: document.getElementById('focus-abilities')
+    };
+
+    if (!boardEl) {
+      return;
+    }
+
+    newGameButton?.addEventListener('click', handleNewGameRequest);
+    playAgainButton?.addEventListener('click', handleNewGameRequest);
+
     buildBoardSkeleton();
     populateCodex();
     startNewGame();
+    window.addEventListener('resize', updateBoardOrientation);
+  }
+
+  function handleNewGameRequest(event) {
+    event?.preventDefault();
+    startNewGame();
+    if (event?.currentTarget instanceof HTMLElement) {
+      event.currentTarget.blur();
+    }
   }
 
   function startNewGame() {
@@ -135,7 +293,9 @@
     gameState = 'playing';
     winner = null;
     endgameEl.hidden = true;
+    clearAbilityState();
     renderBoard();
+    updateBoardOrientation();
     updateHighlights();
     updateCaptured();
     renderMoveLog();
@@ -174,6 +334,26 @@
     const row = Number(cell.dataset.row);
     const col = Number(cell.dataset.col);
     const piece = board[row][col];
+
+    if (activeAbility && abilitySource) {
+      const key = `${row},${col}`;
+      const abilityMove = legalMoveMap.get(key);
+      if (abilityMove) {
+        executeMove(abilitySource.row, abilitySource.col, abilityMove);
+        return;
+      }
+      if (abilitySource.row === row && abilitySource.col === col) {
+        clearAbilityState();
+        setLegalMoves([]);
+        updateHighlights();
+        if (piece) {
+          updatePieceFocus(piece, row, col);
+        }
+        updateStatus('Способность отменена.', `${PLAYERS[currentPlayer].name} выбирает новое действие.`);
+        return;
+      }
+      clearAbilityState();
+    }
 
     const key = `${row},${col}`;
     const move = legalMoveMap.get(key);
@@ -221,63 +401,222 @@
     }
   }
 
+  function clearAbilityState() {
+    activeAbility = null;
+    abilitySource = null;
+  }
+
+  function handleAbilityActivation(row, col, abilityDef) {
+    if (gameState !== 'playing') {
+      return;
+    }
+    const piece = board[row][col];
+    if (!piece || piece.owner !== currentPlayer) {
+      return;
+    }
+    if (piece.energy < abilityDef.cost) {
+      updateStatus('Недостаточно силы для способности.', `Нужно ${abilityDef.cost}, доступно ${piece.energy}.`);
+      return;
+    }
+
+    if (
+      activeAbility &&
+      abilitySource &&
+      activeAbility.id === abilityDef.id &&
+      abilitySource.row === row &&
+      abilitySource.col === col
+    ) {
+      clearAbilityState();
+      setLegalMoves([]);
+      updateHighlights();
+      updatePieceFocus(piece, row, col);
+      updateStatus(`${abilityDef.name} отменена.`, `${PLAYERS[currentPlayer].name} выбирает новое действие.`, false);
+      return;
+    }
+
+    const moves = getAbilityMoves(board, row, col, piece, abilityDef);
+    if (moves.length === 0) {
+      clearAbilityState();
+      setLegalMoves([]);
+      updateHighlights();
+      updatePieceFocus(piece, row, col);
+      updateStatus(`${abilityDef.name} пока невозможна.`, 'Нет допустимых целей.', false);
+      return;
+    }
+
+    activeAbility = abilityDef;
+    abilitySource = { row, col };
+    selectedCell = { row, col };
+    setLegalMoves(moves);
+    updateHighlights();
+    updatePieceFocus(piece, row, col);
+    const coords = moves.map((move) => toNotation(move.row, move.col)).join(', ');
+    updateStatus(`${abilityDef.name} готова.`, `Доступные цели: ${coords}.`, false);
+  }
+
+  function getAbilityMoves(boardState, row, col, piece, abilityDef) {
+    const effect = ABILITY_EFFECTS[abilityDef.id];
+    if (!effect) {
+      return [];
+    }
+    const options = effect.generate(boardState, row, col, piece, abilityDef) || [];
+    const legal = [];
+    for (const option of options) {
+      const simulation = cloneBoard(boardState);
+      const simPiece = simulation[row][col];
+      if (!simPiece) {
+        continue;
+      }
+      const result = effect.apply(simulation, row, col, simPiece, option, abilityDef);
+      if (!result) {
+        continue;
+      }
+      const commander = findCommander(simulation, piece.owner);
+      if (!commander) {
+        continue;
+      }
+      if (isSquareUnderAttack(simulation, commander.row, commander.col, otherPlayer(piece.owner))) {
+        continue;
+      }
+      legal.push({
+        ...option,
+        abilityId: abilityDef.id,
+        abilityName: abilityDef.name,
+        capture:
+          option.capture !== undefined
+            ? option.capture
+            : Boolean(option.type === 'strike'
+                ? boardState[option.row][option.col] && boardState[option.row][option.col].owner !== piece.owner
+                : boardState[option.row]?.[option.col] && boardState[option.row][option.col].owner !== piece.owner),
+        promotion: option.promotion || null
+      });
+    }
+    return legal;
+  }
+
   function executeMove(fromRow, fromCol, move) {
     const piece = board[fromRow][fromCol];
     if (!piece) {
       return;
     }
 
-    const target = board[move.row][move.col];
     const originalType = piece.type;
     const opponent = otherPlayer(piece.owner);
-    const notation = `${toNotation(fromRow, fromCol)} → ${toNotation(move.row, move.col)}`;
+    const abilityDef = move.abilityId ? getAbilityDefinition(originalType, move.abilityId) : null;
+    const effect = abilityDef ? ABILITY_EFFECTS[abilityDef.id] : null;
 
-    if (target) {
-      capturedPieces[piece.owner].push(target.type);
+    let target = board[move.row]?.[move.col] || null;
+    let captureOccurred = Boolean(target);
+    let promotionType = move.promotion || null;
+    let finalRow = move.row;
+    let finalCol = move.col;
+    let stayedInPlace = false;
+    let notationSymbol = null;
+
+    if (abilityDef) {
+      if (!effect) {
+        return;
+      }
+      const result = effect.apply(board, fromRow, fromCol, piece, move, abilityDef);
+      if (!result) {
+        return;
+      }
+      finalRow = result.finalRow;
+      finalCol = result.finalCol;
+      promotionType = result.promotion || promotionType;
+      captureOccurred = Boolean(result.capture);
+      target = result.capturedPiece || null;
+      stayedInPlace = Boolean(result.stayPut);
+      notationSymbol = result.notationSymbol || null;
+      if (captureOccurred && target) {
+        capturedPieces[piece.owner].push(target.type);
+      }
+    } else {
+      if (target) {
+        capturedPieces[piece.owner].push(target.type);
+      }
+      board[move.row][move.col] = piece;
+      board[fromRow][fromCol] = null;
+      piece.moved = true;
+      if (move.promotion) {
+        promotionType = move.promotion;
+        piece.promotedFrom = piece.promotedFrom || piece.type;
+        piece.type = promotionType;
+      }
     }
 
-    board[move.row][move.col] = piece;
-    board[fromRow][fromCol] = null;
-    piece.moved = true;
+    const victoryByCapture = target && target.type === 'commander' && captureOccurred;
 
-    let promotionType = null;
-    if (move.promotion) {
-      promotionType = move.promotion;
-      piece.promotedFrom = piece.promotedFrom || piece.type;
-      piece.type = promotionType;
+    clearAbilityState();
+    selectedCell = null;
+    setLegalMoves([]);
+
+    const movedPiece = board[finalRow][finalCol] || board[fromRow][fromCol] || piece;
+    const distance = stayedInPlace ? 0 : calculateDistance(fromRow, fromCol, finalRow, finalCol);
+    let energyGain = distance;
+    if (captureOccurred && target) {
+      energyGain += CAPTURE_REWARD[target.type] || 0;
+    }
+    if (abilityDef) {
+      movedPiece.energy = Math.max(0, movedPiece.energy - abilityDef.cost);
+    }
+    movedPiece.energy = Math.min(MAX_ENERGY, movedPiece.energy + energyGain);
+    movedPiece.moved = true;
+
+    let notationFrom = toNotation(fromRow, fromCol);
+    let notationTo = toNotation(finalRow, finalCol);
+    let notation;
+    if (abilityDef) {
+      if (move.type === 'strike') {
+        notation = `${notationFrom} ⚡ ${toNotation(move.row, move.col)}`;
+      } else if (move.type === 'swap' || move.type === 'swap-enemy') {
+        notation = `${notationFrom} ⇄ ${notationTo}`;
+      } else {
+        notation = `${notationFrom} ⇢ ${notationTo}`;
+      }
+      if (notationSymbol) {
+        notation += ` ${notationSymbol}`;
+      }
+    } else {
+      notation = `${notationFrom} → ${notationTo}`;
     }
 
     const moveEntry = {
-      player: piece.owner,
+      player: movedPiece.owner,
       pieceType: originalType,
       notation,
-      capture: Boolean(target),
+      capture: captureOccurred,
       promotion: promotionType,
+      ability: abilityDef ? abilityDef.name : null,
       check: false,
       checkmate: false,
       stalemate: false
     };
 
-    const victoryByCapture = target && target.type === 'commander';
-
-    selectedCell = null;
-    setLegalMoves([]);
     renderBoard();
     updateCaptured();
 
     if (victoryByCapture) {
       moveEntry.checkmate = true;
       moveHistory.push(moveEntry);
-      finalizeGame(piece.owner, `${PIECES[originalType].name} пленил Командора ${PLAYERS[opponent].name}.`, 'Решающее столкновение завершило поединок.');
+      const action = abilityDef ? `способностью «${abilityDef.name}»` : 'точным манёвром';
+      finalizeGame(
+        movedPiece.owner,
+        `${PIECES[originalType].name} пленил Командора ${PLAYERS[opponent].name}.`,
+        `Решающее столкновение завершено, использована ${action}.`
+      );
       return;
     }
 
     const opponentCommander = findCommander(board, opponent);
-    const givesCheck = opponentCommander ? isSquareUnderAttack(board, opponentCommander.row, opponentCommander.col, piece.owner) : false;
+    const givesCheck = opponentCommander
+      ? isSquareUnderAttack(board, opponentCommander.row, opponentCommander.col, movedPiece.owner)
+      : false;
     moveEntry.check = givesCheck;
     moveHistory.push(moveEntry);
 
     currentPlayer = opponent;
+    updateBoardOrientation();
 
     const opponentHasMoves = hasLegalMoves(board, opponent);
     const opponentInCheck = isCommanderInCheck(board, opponent);
@@ -285,7 +624,11 @@
     if (!opponentHasMoves) {
       if (opponentInCheck) {
         moveEntry.checkmate = true;
-        finalizeGame(piece.owner, `${PLAYERS[piece.owner].name} ставит мат.`, `${PLAYERS[opponent].name} не может спасти Командора.`);
+        finalizeGame(
+          movedPiece.owner,
+          `${PLAYERS[movedPiece.owner].name} ставит мат.`,
+          `${PLAYERS[opponent].name} не может спасти Командора.`
+        );
       } else {
         moveEntry.stalemate = true;
         finalizeGame(null, 'Перемирие — пат.', 'Оба ордена выдыхают и объявляют ничью.');
@@ -298,14 +641,25 @@
     updatePieceFocus(null);
     updateTurnPanel();
 
-    const actorName = PLAYERS[piece.owner].name;
+    const actorName = PLAYERS[movedPiece.owner].name;
     const opponentName = PLAYERS[opponent].name;
-    let primary = `${actorName} перемещает ${PIECES[originalType].name} на ${toNotation(move.row, move.col)}.`;
-    if (target) {
-      primary += ` Взято: ${PIECES[target.type].name}.`;
-    }
-    if (promotionType) {
-      primary += ` Повышение до ${PIECES[piece.type].name}.`;
+    let primary;
+    if (abilityDef) {
+      primary = `${actorName} задействует «${abilityDef.name}» у ${PIECES[originalType].name}.`;
+      if (captureOccurred && target) {
+        primary += ` Цель: ${PIECES[target.type].name}.`;
+      }
+      if (promotionType) {
+        primary += ` Повышение до ${PIECES[movedPiece.type].name}.`;
+      }
+    } else {
+      primary = `${actorName} перемещает ${PIECES[originalType].name} на ${notationTo}.`;
+      if (captureOccurred && target) {
+        primary += ` Взято: ${PIECES[target.type].name}.`;
+      }
+      if (promotionType) {
+        primary += ` Повышение до ${PIECES[movedPiece.type].name}.`;
+      }
     }
 
     let secondary;
@@ -339,6 +693,7 @@
     endgameEl.hidden = false;
     updateStatus(heading, detail);
     renderMoveLog();
+    updateBoardOrientation();
   }
 
   function setLegalMoves(moves) {
@@ -372,8 +727,19 @@
         sr.textContent = `${def.name} игрока ${PLAYERS[piece.owner].name}`;
         wrapper.appendChild(glyph);
         wrapper.appendChild(sr);
+        if (piece.energy > 0) {
+          const energyBadge = document.createElement('span');
+          energyBadge.className = 'piece__energy';
+          energyBadge.textContent = piece.energy;
+          energyBadge.setAttribute('aria-hidden', 'true');
+          wrapper.appendChild(energyBadge);
+        }
         cell.appendChild(wrapper);
-        cell.setAttribute('aria-label', `${def.name} ${PLAYERS[piece.owner].name} на клетке ${toNotation(row, col)}`);
+        let label = `${def.name} ${PLAYERS[piece.owner].name} на клетке ${toNotation(row, col)}`;
+        if (piece.energy > 0) {
+          label += `. Сила: ${piece.energy}.`;
+        }
+        cell.setAttribute('aria-label', label);
       }
     }
     updateCommanderAlerts();
@@ -383,13 +749,16 @@
     for (let row = 0; row < BOARD_SIZE; row += 1) {
       for (let col = 0; col < BOARD_SIZE; col += 1) {
         const cell = cellElements[row][col];
-        cell.classList.remove('cell--selected', 'cell--move', 'cell--capture');
+        cell.classList.remove('cell--selected', 'cell--move', 'cell--capture', 'cell--ability');
         if (selectedCell && selectedCell.row === row && selectedCell.col === col) {
           cell.classList.add('cell--selected');
         }
         const key = `${row},${col}`;
         if (legalMoveMap.has(key)) {
           const move = legalMoveMap.get(key);
+          if (move.abilityId) {
+            cell.classList.add('cell--ability');
+          }
           cell.classList.add(move.capture ? 'cell--capture' : 'cell--move');
         }
       }
@@ -413,6 +782,18 @@
         cell.classList.add('cell--alert');
       }
     });
+  }
+
+  function updateBoardOrientation() {
+    if (!boardFrame) {
+      return;
+    }
+    const tabletopMode = window.matchMedia('(max-width: 720px)').matches;
+    let facingPlayer = currentPlayer;
+    if (gameState === 'ended') {
+      facingPlayer = winner !== null ? winner : 'dawn';
+    }
+    boardFrame.classList.toggle('board-frame--flipped', tabletopMode && facingPlayer === 'dusk');
   }
 
   function updateStatus(primary, secondary = '', announce = true) {
@@ -521,9 +902,15 @@
     const notation = document.createElement('span');
     notation.className = 'move-log__notation';
     notation.textContent = `${PIECES[entry.pieceType].glyph[entry.player]} ${entry.notation}`;
+    if (entry.ability) {
+      notation.textContent += ' ✦';
+    }
     const detail = document.createElement('p');
     detail.className = 'move-log__detail';
     const flags = [];
+    if (entry.ability) {
+      flags.push(`приём: ${entry.ability}`);
+    }
     if (entry.capture) {
       flags.push('взято');
     }
@@ -546,6 +933,8 @@
   function updatePieceFocus(piece, row, col) {
     focusEls.traits.innerHTML = '';
     focusEls.stats.innerHTML = '';
+    focusEls.abilities.innerHTML = '';
+    focusEls.energy.textContent = '';
     if (!piece) {
       focusEls.card.classList.add('focus-card--empty');
       focusEls.glyph.textContent = '☆';
@@ -556,6 +945,10 @@
       focusEls.position.textContent = '';
       focusEls.status.textContent = '';
       focusEls.promotion.textContent = '';
+      const abilityPlaceholder = document.createElement('p');
+      abilityPlaceholder.className = 'focus-card__abilities-placeholder';
+      abilityPlaceholder.textContent = 'Способности появятся после выбора фигуры.';
+      focusEls.abilities.appendChild(abilityPlaceholder);
       const placeholder = document.createElement('li');
       placeholder.className = 'tag-list__placeholder';
       placeholder.textContent = 'Тактическое досье появится здесь';
@@ -572,6 +965,7 @@
     focusEls.movement.textContent = def.movement;
     focusEls.position.textContent = `Позиция: ${toNotation(row, col)}`;
     focusEls.status.textContent = piece.moved ? 'Уже участвовал в манёврах.' : 'Пока не двигался.';
+    focusEls.energy.textContent = `Сила: ${piece.energy}`;
     if (piece.promotedFrom && piece.promotedFrom !== piece.type) {
       focusEls.promotion.textContent = `Повышен из ${PIECES[piece.promotedFrom].name}.`;
     } else {
@@ -591,6 +985,51 @@
       dd.textContent = value;
       focusEls.stats.append(dt, dd);
     });
+
+    if (def.abilities && def.abilities.length > 0) {
+      def.abilities.forEach((ability) => {
+        const item = document.createElement('div');
+        item.className = 'ability';
+        const header = document.createElement('div');
+        header.className = 'ability__header';
+        const title = document.createElement('h4');
+        title.className = 'ability__name';
+        title.textContent = ability.name;
+        const cost = document.createElement('span');
+        cost.className = 'ability__cost';
+        cost.textContent = `${ability.cost} ⚡`;
+        header.append(title, cost);
+        const description = document.createElement('p');
+        description.className = 'ability__description';
+        description.textContent = ability.description;
+        item.append(header, description);
+        if (piece.owner === currentPlayer && gameState === 'playing') {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'ability__button';
+          button.textContent = piece.energy >= ability.cost ? 'Активировать' : 'Недостаточно силы';
+          button.disabled = piece.energy < ability.cost;
+          if (
+            activeAbility &&
+            abilitySource &&
+            abilitySource.row === row &&
+            abilitySource.col === col &&
+            activeAbility.id === ability.id
+          ) {
+            button.classList.add('ability__button--active');
+            button.textContent = 'Выбор цели';
+          }
+          button.addEventListener('click', () => handleAbilityActivation(row, col, ability));
+          item.appendChild(button);
+        }
+        focusEls.abilities.appendChild(item);
+      });
+    } else {
+      const abilityPlaceholder = document.createElement('p');
+      abilityPlaceholder.className = 'focus-card__abilities-placeholder';
+      abilityPlaceholder.textContent = 'Особых приёмов не заявлено.';
+      focusEls.abilities.appendChild(abilityPlaceholder);
+    }
   }
 
   function populateCodex() {
@@ -635,6 +1074,24 @@
         stats.append(dt, dd);
       });
       card.append(header, desc, move, traits, stats);
+      if (def.abilities && def.abilities.length > 0) {
+        const abilityBlock = document.createElement('div');
+        abilityBlock.className = 'codex-card__abilities';
+        const abilityTitle = document.createElement('h4');
+        abilityTitle.textContent = 'Способности';
+        abilityBlock.appendChild(abilityTitle);
+        def.abilities.forEach((ability) => {
+          const abilityRow = document.createElement('div');
+          abilityRow.className = 'codex-card__ability';
+          const abilityName = document.createElement('strong');
+          abilityName.textContent = `${ability.name} — ${ability.cost}⚡`;
+          const abilityDesc = document.createElement('p');
+          abilityDesc.textContent = ability.description;
+          abilityRow.append(abilityName, abilityDesc);
+          abilityBlock.appendChild(abilityRow);
+        });
+        card.appendChild(abilityBlock);
+      }
       codexEl.appendChild(card);
     });
   }
@@ -649,20 +1106,40 @@
     return player === 'dawn' ? 'dusk' : 'dawn';
   }
 
+  function getAbilityDefinition(type, abilityId) {
+    const def = PIECES[type];
+    if (!def || !def.abilities) {
+      return null;
+    }
+    return def.abilities.find((ability) => ability.id === abilityId) || null;
+  }
+
   function createInitialBoard() {
-    const backline = ['sentinel', 'lancer', 'commander', 'strider', 'lancer', 'sentinel'];
+    const backline = [
+      'sentinel',
+      'lancer',
+      'strider',
+      'sentinel',
+      'commander',
+      'strider',
+      'sentinel',
+      'strider',
+      'lancer',
+      'sentinel'
+    ];
     const boardState = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
     for (let col = 0; col < BOARD_SIZE; col += 1) {
-      boardState[0][col] = createPiece(backline[col], 'dusk');
+      const pieceType = backline[col % backline.length];
+      boardState[0][col] = createPiece(pieceType, 'dusk');
       boardState[1][col] = createPiece('squire', 'dusk');
       boardState[BOARD_SIZE - 2][col] = createPiece('squire', 'dawn');
-      boardState[BOARD_SIZE - 1][col] = createPiece(backline[col], 'dawn');
+      boardState[BOARD_SIZE - 1][col] = createPiece(pieceType, 'dawn');
     }
     return boardState;
   }
 
   function createPiece(type, owner) {
-    return { type, owner, moved: false };
+    return { type, owner, moved: false, energy: 0 };
   }
 
   function cloneBoard(boardState) {
@@ -718,6 +1195,21 @@
       });
     }
     return legal;
+  }
+
+  function calculateDistance(fromRow, fromCol, toRow, toCol) {
+    const dr = Math.abs(fromRow - toRow);
+    const dc = Math.abs(fromCol - toCol);
+    if ((dr === 2 && dc === 1) || (dr === 1 && dc === 2)) {
+      return 3;
+    }
+    if (dr === dc) {
+      return dr;
+    }
+    if (dr === 0 || dc === 0) {
+      return dr + dc;
+    }
+    return dr + dc;
   }
 
   function hasLegalMoves(boardState, player) {
@@ -897,5 +1389,342 @@
     return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
   }
 
-  start();
+  function generateRadiantStepOptions(boardState, row, col, piece) {
+    const moves = [];
+    for (let dr = -1; dr <= 1; dr += 1) {
+      for (let dc = -1; dc <= 1; dc += 1) {
+        if (dr === 0 && dc === 0) {
+          continue;
+        }
+        for (let step = 1; step <= 2; step += 1) {
+          const r = row + dr * step;
+          const c = col + dc * step;
+          if (!isInside(r, c)) {
+            break;
+          }
+          if (step === 2) {
+            const midRow = row + dr;
+            const midCol = col + dc;
+            if (boardState[midRow][midCol]) {
+              break;
+            }
+          }
+          const occupant = boardState[r][c];
+          if (occupant && occupant.owner === piece.owner) {
+            break;
+          }
+          moves.push({ row: r, col: c, type: 'move', capture: Boolean(occupant && occupant.owner !== piece.owner) });
+          if (occupant) {
+            break;
+          }
+        }
+      }
+    }
+    return moves;
+  }
+
+  function generateAstralSwapOptions(boardState, row, col, piece) {
+    const moves = [];
+    for (let r = 0; r < BOARD_SIZE; r += 1) {
+      for (let c = 0; c < BOARD_SIZE; c += 1) {
+        if (r === row && c === col) {
+          continue;
+        }
+        const occupant = boardState[r][c];
+        if (!occupant || occupant.owner !== piece.owner) {
+          continue;
+        }
+        const distance = Math.abs(row - r) + Math.abs(col - c);
+        if (distance > 3) {
+          continue;
+        }
+        moves.push({ row: r, col: c, type: 'swap', capture: false });
+      }
+    }
+    return moves;
+  }
+
+  function generateIronDiagonalOptions(boardState, row, col, piece) {
+    const moves = [];
+    const directions = [
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1]
+    ];
+    directions.forEach(([dr, dc]) => {
+      for (let step = 1; step <= 2; step += 1) {
+        const r = row + dr * step;
+        const c = col + dc * step;
+        if (!isInside(r, c)) {
+          break;
+        }
+        if (step === 2) {
+          const midRow = row + dr;
+          const midCol = col + dc;
+          if (boardState[midRow][midCol]) {
+            break;
+          }
+        }
+        const occupant = boardState[r][c];
+        if (occupant && occupant.owner === piece.owner) {
+          break;
+        }
+        moves.push({ row: r, col: c, type: 'move', capture: Boolean(occupant && occupant.owner !== piece.owner) });
+        if (occupant) {
+          break;
+        }
+      }
+    });
+    return moves;
+  }
+
+  function generateSiegeBoltOptions(boardState, row, col, piece) {
+    const moves = [];
+    const directions = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1]
+    ];
+    directions.forEach(([dr, dc]) => {
+      let r = row + dr;
+      let c = col + dc;
+      let step = 1;
+      while (isInside(r, c) && step <= 3) {
+        const occupant = boardState[r][c];
+        if (occupant) {
+          if (occupant.owner !== piece.owner) {
+            moves.push({ row: r, col: c, type: 'strike', capture: true });
+          }
+          break;
+        }
+        r += dr;
+        c += dc;
+        step += 1;
+      }
+    });
+    return moves;
+  }
+
+  function generateHorizonDriftOptions(boardState, row, col, piece) {
+    const moves = [];
+    const directions = [
+      [0, 1],
+      [0, -1]
+    ];
+    directions.forEach(([dr, dc]) => {
+      for (let step = 1; step <= 2; step += 1) {
+        const r = row + dr * step;
+        const c = col + dc * step;
+        if (!isInside(r, c)) {
+          break;
+        }
+        if (step === 2) {
+          const midRow = row + dr;
+          const midCol = col + dc;
+          if (boardState[midRow][midCol]) {
+            break;
+          }
+        }
+        const occupant = boardState[r][c];
+        if (occupant && occupant.owner === piece.owner) {
+          break;
+        }
+        moves.push({ row: r, col: c, type: 'move', capture: Boolean(occupant && occupant.owner !== piece.owner) });
+        if (occupant) {
+          break;
+        }
+      }
+    });
+    return moves;
+  }
+
+  function generatePrismGateOptions(boardState, row, col) {
+    const moves = [];
+    const directions = [
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1]
+    ];
+    directions.forEach(([dr, dc]) => {
+      const r = row + dr * 3;
+      const c = col + dc * 3;
+      if (!isInside(r, c)) {
+        return;
+      }
+      if (!boardState[r][c]) {
+        moves.push({ row: r, col: c, type: 'move', capture: false });
+      }
+    });
+    return moves;
+  }
+
+  function generateMeteorDashOptions(boardState, row, col, piece) {
+    const moves = [];
+    const directions = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1]
+    ];
+    directions.forEach(([dr, dc]) => {
+      let r = row + dr;
+      let c = col + dc;
+      let step = 1;
+      while (isInside(r, c) && step <= 3) {
+        const occupant = boardState[r][c];
+        if (occupant) {
+          if (occupant.owner !== piece.owner) {
+            moves.push({ row: r, col: c, type: 'move', capture: true });
+          }
+          break;
+        }
+        moves.push({ row: r, col: c, type: 'move', capture: false });
+        r += dr;
+        c += dc;
+        step += 1;
+      }
+    });
+    return moves;
+  }
+
+  function generateStormReversalOptions(boardState, row, col, piece) {
+    const moves = [];
+    const jumps = [
+      [2, 1], [2, -1],
+      [-2, 1], [-2, -1],
+      [1, 2], [1, -2],
+      [-1, 2], [-1, -2]
+    ];
+    jumps.forEach(([dr, dc]) => {
+      const r = row + dr;
+      const c = col + dc;
+      if (!isInside(r, c)) {
+        return;
+      }
+      const occupant = boardState[r][c];
+      if (occupant && occupant.owner !== piece.owner) {
+        moves.push({ row: r, col: c, type: 'swap-enemy', capture: false });
+      }
+    });
+    return moves;
+  }
+
+  function generateLineSurgeOptions(boardState, row, col, piece) {
+    const moves = [];
+    const dir = directionByPlayer[piece.owner];
+    const firstRow = row + dir;
+    const secondRow = row + dir * 2;
+    if (
+      isInside(firstRow, col) &&
+      !boardState[firstRow][col] &&
+      isInside(secondRow, col) &&
+      !boardState[secondRow][col]
+    ) {
+      const promotion = secondRow === promotionRowFor(piece.owner) ? 'strider' : null;
+      moves.push({ row: secondRow, col, type: 'move', capture: false, promotion });
+    }
+    return moves;
+  }
+
+  function generateHookStrikeOptions(boardState, row, col, piece) {
+    const moves = [];
+    const dir = directionByPlayer[piece.owner];
+    const targetRow = row + dir;
+    if (!isInside(targetRow, col)) {
+      return moves;
+    }
+    const occupant = boardState[targetRow][col];
+    if (occupant && occupant.owner !== piece.owner) {
+      const promotion = targetRow === promotionRowFor(piece.owner) ? 'strider' : null;
+      moves.push({ row: targetRow, col, type: 'move', capture: true, promotion });
+    }
+    return moves;
+  }
+
+  function applyStandardAbilityMove(boardState, fromRow, fromCol, piece, option) {
+    const target = boardState[option.row][option.col];
+    if (target && target.owner === piece.owner) {
+      return null;
+    }
+    boardState[option.row][option.col] = piece;
+    boardState[fromRow][fromCol] = null;
+    piece.moved = true;
+    if (option.promotion) {
+      piece.promotedFrom = piece.promotedFrom || piece.type;
+      piece.type = option.promotion;
+    }
+    const captured = target && target.owner !== piece.owner ? target : null;
+    return {
+      finalRow: option.row,
+      finalCol: option.col,
+      capture: Boolean(captured),
+      capturedPiece: captured,
+      promotion: option.promotion || null
+    };
+  }
+
+  function applyAstralSwap(boardState, fromRow, fromCol, piece, option) {
+    const ally = boardState[option.row][option.col];
+    if (!ally || ally.owner !== piece.owner) {
+      return null;
+    }
+    boardState[option.row][option.col] = piece;
+    boardState[fromRow][fromCol] = ally;
+    piece.moved = true;
+    ally.moved = true;
+    return {
+      finalRow: option.row,
+      finalCol: option.col,
+      capture: false,
+      capturedPiece: null
+    };
+  }
+
+  function applySiegeBolt(boardState, fromRow, fromCol, piece, option) {
+    const enemy = boardState[option.row][option.col];
+    if (!enemy || enemy.owner === piece.owner) {
+      return null;
+    }
+    boardState[option.row][option.col] = null;
+    piece.moved = true;
+    return {
+      finalRow: fromRow,
+      finalCol: fromCol,
+      capture: true,
+      capturedPiece: enemy,
+      stayPut: true,
+      notationSymbol: '☄'
+    };
+  }
+
+  function applyStormReversal(boardState, fromRow, fromCol, piece, option) {
+    const enemy = boardState[option.row][option.col];
+    if (!enemy || enemy.owner === piece.owner) {
+      return null;
+    }
+    boardState[option.row][option.col] = piece;
+    boardState[fromRow][fromCol] = enemy;
+    piece.moved = true;
+    enemy.moved = true;
+    return {
+      finalRow: option.row,
+      finalCol: option.col,
+      capture: false,
+      capturedPiece: null,
+      notationSymbol: '↺'
+    };
+  }
+
+  whenReady(initialize);
+
+  function whenReady(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  }
 })();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ body {
 
 button {
   font: inherit;
+  touch-action: manipulation;
 }
 
 .shell {
@@ -114,6 +115,11 @@ button {
   gap: clamp(18px, 3vw, 28px);
 }
 
+.hud {
+  display: grid;
+  gap: clamp(18px, 3vw, 26px);
+}
+
 .board-frame {
   position: relative;
   padding: clamp(12px, 3vw, 18px);
@@ -121,13 +127,20 @@ button {
   background: linear-gradient(150deg, rgba(48, 78, 143, 0.45), rgba(13, 21, 38, 0.9));
   border: 1px solid rgba(142, 186, 255, 0.18);
   box-shadow: 0 20px 55px rgba(6, 8, 20, 0.6);
+  transition: transform 0.4s ease;
+  transform-origin: center;
+}
+
+.board-frame--flipped {
+  transform: rotate(180deg);
 }
 
 .board {
-  --board-size: 6;
+  --board-size: 10;
   display: grid;
-  grid-template-columns: repeat(var(--board-size), minmax(52px, 1fr));
-  gap: clamp(6px, 1.4vw, 10px);
+  grid-template-columns: repeat(var(--board-size), minmax(48px, 1fr));
+  gap: clamp(5px, 1.3vw, 9px);
+  transition: transform 0.4s ease;
 }
 
 .cell {
@@ -189,6 +202,13 @@ button {
   transform: scale(1);
 }
 
+.cell--ability::after {
+  background: radial-gradient(circle, rgba(186, 160, 255, 0.75), rgba(112, 88, 188, 0.55));
+  opacity: 0.85;
+  transform: scale(1);
+  box-shadow: 0 0 18px rgba(170, 140, 255, 0.55);
+}
+
 .cell--alert::after {
   background: var(--highlight-check);
   opacity: 0.9;
@@ -199,6 +219,7 @@ button {
 .piece {
   width: 72%;
   height: 72%;
+  position: relative;
   border-radius: 20px;
   display: flex;
   align-items: center;
@@ -221,6 +242,27 @@ button {
 
 .piece__glyph {
   text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+}
+
+.piece__energy {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.88);
+  color: #1b213c;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.piece--dawn .piece__energy {
+  color: #2d1604;
+}
+
+.piece--dusk .piece__energy {
+  color: #0a1a44;
 }
 
 .status {
@@ -271,6 +313,10 @@ button {
   color: var(--text-muted);
   font-size: 0.85rem;
   line-height: 1.4;
+}
+
+.hud .panel {
+  height: 100%;
 }
 
 .player-card {
@@ -444,6 +490,91 @@ button {
   color: #ffd4ba;
 }
 
+.focus-card__energy {
+  color: #b8e5ff;
+  font-weight: 600;
+}
+
+.focus-card__abilities {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 12px;
+}
+
+.focus-card__abilities-placeholder {
+  margin: 0;
+  color: rgba(190, 205, 240, 0.6);
+  font-size: 0.85rem;
+}
+
+.ability {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(150, 190, 255, 0.16);
+  display: grid;
+  gap: 6px;
+}
+
+.ability__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ability__name {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.ability__cost {
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ffe6a8;
+}
+
+.ability__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.ability__button {
+  justify-self: flex-start;
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: none;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(122, 165, 255, 0.9), rgba(178, 215, 255, 0.85));
+  color: #081432;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.ability__button:hover,
+.ability__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(122, 165, 255, 0.35);
+}
+
+.ability__button:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.4);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.ability__button--active {
+  background: linear-gradient(135deg, rgba(246, 212, 127, 0.95), rgba(255, 184, 125, 0.95));
+  color: #2a1604;
+}
+
 .focus-card__traits,
 .focus-card__stats {
   grid-column: 1 / -1;
@@ -559,6 +690,39 @@ button {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.codex-card__abilities {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.codex-card__abilities h4 {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 212, 255, 0.7);
+}
+
+.codex-card__ability {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: grid;
+  gap: 4px;
+}
+
+.codex-card__ability strong {
+  font-size: 0.85rem;
+}
+
+.codex-card__ability p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
   line-height: 1.4;
 }
 
@@ -685,6 +849,11 @@ button {
   box-shadow: 0 12px 28px rgba(122, 165, 255, 0.35);
 }
 
+.endgame[hidden] {
+  display: none !important;
+  pointer-events: none;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -696,24 +865,148 @@ button {
   border: 0;
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
+  .shell {
+    padding: clamp(14px, 5vw, 32px);
+  }
+
   .layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .board-area {
+    align-items: center;
+  }
+
+  .board-frame {
+    width: min(100%, 520px);
+    margin: 0 auto;
   }
 
   .hero {
     flex-direction: column;
     align-items: stretch;
+    text-align: center;
+    gap: clamp(18px, 4vw, 32px);
+  }
+
+  .hero__text {
+    align-items: center;
+  }
+
+  .hero__subtitle {
+    max-width: 52ch;
   }
 
   .hero__button {
-    align-self: flex-start;
+    align-self: center;
+  }
+}
+
+@media (max-width: 900px) {
+  .board-frame {
+    padding: clamp(10px, 4vw, 16px);
+  }
+
+  .status {
+    padding: 14px 18px;
+  }
+
+  .panel {
+    padding: clamp(14px, 4vw, 20px);
+  }
+
+  .move-log {
+    max-height: clamp(200px, 36vh, 280px);
   }
 }
 
 @media (max-width: 720px) {
+  .shell {
+    gap: clamp(18px, 6vw, 28px);
+  }
+
+  .hero {
+    padding: clamp(16px, 6vw, 28px);
+  }
+
+  .hero__button {
+    width: 100%;
+    align-self: stretch;
+  }
+
+  .hero__subtitle {
+    max-width: unset;
+  }
+
+  .board-area {
+    align-items: stretch;
+  }
+
   .board {
     grid-template-columns: repeat(var(--board-size), minmax(40px, 1fr));
+  }
+
+  .board-frame {
+    width: min(100%, 520px);
+    margin: 0 auto;
+  }
+
+  .layout {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .board-area {
+    order: 2;
+  }
+
+  .hud {
+    order: 3;
+    display: contents;
+  }
+
+  .panel--players {
+    order: 1;
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 4vw, 18px);
+    align-items: center;
+  }
+
+  .panel--players .player-card {
+    width: min(100%, 340px);
+  }
+
+  .panel--players .player-card[data-player="dusk"] {
+    transform: rotate(180deg);
+    transform-origin: center;
+  }
+
+  .panel--focus {
+    order: 3;
+  }
+
+  .panel--codex {
+    order: 4;
+  }
+
+  .panel--rules {
+    order: 5;
+  }
+
+  .panel__title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .codex {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 
   .move-log__row {
@@ -722,6 +1015,33 @@ button {
 }
 
 @media (max-width: 540px) {
+  .hero__overtitle {
+    letter-spacing: 0.26em;
+    font-size: 0.7rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(1.8rem, 8vw, 2.3rem);
+  }
+
+  .hero__subtitle {
+    font-size: 0.95rem;
+  }
+
+  .board {
+    grid-template-columns: repeat(var(--board-size), minmax(36px, 1fr));
+    gap: clamp(4px, 3vw, 8px);
+  }
+
+  .cell {
+    border-radius: 16px;
+  }
+
+  .piece {
+    border-radius: 16px;
+    font-size: clamp(1.5rem, 7vw, 1.9rem);
+  }
+
   .focus-card {
     grid-template-columns: 1fr;
     text-align: left;
@@ -729,5 +1049,39 @@ button {
 
   .focus-card__glyph {
     justify-self: flex-start;
+  }
+
+  .panel {
+    padding: clamp(12px, 5vw, 18px);
+  }
+}
+
+@media (max-width: 420px) {
+  .hero {
+    gap: 20px;
+  }
+
+  .hero__text {
+    gap: 10px;
+  }
+
+  .board-frame {
+    border-radius: 22px;
+  }
+
+  .panel__title {
+    font-size: 1rem;
+  }
+
+  .panel__subtitle {
+    font-size: 0.82rem;
+  }
+
+  .tag-list {
+    gap: 6px;
+  }
+
+  .stat-list {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- expand the tactical board to 10×10 and introduce unique rune glyphs plus dual abilities for every unit, powered by an energy resource from movement and captures
- surface energy, ability activation, and codex details in the HUD while preserving engine safety via legal-move simulations for every ability
- add tabletop-friendly orientation that flips toward the active side on mobile, refining responsive layouts for shared phone play

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_690204e288e88320a338d9ffe8610b0f