### PR TITLE
Создать славянскую версию лазерных шахмат

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,125 +2,66 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Астральный двор —  стратегов</title>
+  <title>Лучезарная сечь</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <main class="shell">
-    <header class="hero">
-      <div class="hero__text">
-        <p class="hero__overtitle">Тактическая дуэль на двоих</p>
-        <h1>Астральный двор</h1>
-        <p class="hero__subtitle">Управляйте эскадрами Орденов Рассвета и Сумрака, командуйте уникальными фигурами и переграйте соперника в поединке света и тени.</p>
-      </div>
-      <button type="button" id="new-game" class="hero__button">Новая партия</button>
-    </header>
+  <main class="game">
+    <aside class="sidebar">
+      <header class="sidebar__hero">
+        <p class="sidebar__overtitle">Дуэль лучезарных волхвов</p>
+        <h1>Лучезарная сечь</h1>
+        <p class="sidebar__intro">Поверните зеркала, направьте лучи Перуна и Чернобога и сразите чужого волхва, не подпуская свет к своему.</p>
+        <button type="button" id="new-game" class="button button--primary">Новая партия</button>
+      </header>
 
-    <div class="layout">
-      <section class="board-area">
-        <div class="board-frame">
-          <div id="board" class="board" role="grid" aria-label="Игровое поле Астрального двора"></div>
-          <div id="endgame" class="endgame" aria-live="assertive" hidden>
-            <h2 id="endgame-title"></h2>
-            <p id="endgame-subtitle"></p>
-            <button type="button" id="play-again" class="endgame__button">Сыграть ещё</button>
-          </div>
-        </div>
-
-        <div id="status" class="status" role="status" aria-live="polite">
-          <p id="status-primary"></p>
-          <p id="status-secondary"></p>
-        </div>
-
-        <section class="log panel">
-          <div class="panel__title-row">
-            <h2 class="panel__title">Летопись ходов</h2>
-            <p class="panel__subtitle">Отслеживайте развитие дуэли по ходам</p>
-          </div>
-          <ol id="move-log" class="move-log" aria-live="polite"></ol>
-        </section>
+      <section class="panel">
+        <h2>Ход</h2>
+        <p id="turn-indicator" class="panel__turn">—</p>
       </section>
 
-      <aside class="hud">
-        <section class="panel panel--players">
-          <h2 class="panel__title">Командование</h2>
-          <p class="panel__subtitle">Выберите фигуру своего ордена, чтобы вывести её характеристики.</p>
-          <div class="player-card" data-player="dawn">
-            <header class="player-card__header">
-              <div class="player-card__crest" aria-hidden="true"></div>
-              <div>
-                <h3>Орден Рассвета</h3>
-                <p class="player-card__tagline">Атакует молниеносно и удерживает пространство.</p>
-              </div>
-              <span id="turn-dawn" class="player-card__turn" aria-live="polite">Ход</span>
-            </header>
-            <div class="player-card__body">
-              <p class="player-card__label">Трофеи</p>
-              <div id="captured-dawn" class="captured" aria-label="Захвачено Орденом Рассвета"></div>
-            </div>
-          </div>
+      <section class="panel">
+        <h2>Действия</h2>
+        <div class="actions">
+          <button type="button" id="rotate-left" class="button" disabled>Повернуть ↺</button>
+          <button type="button" id="rotate-right" class="button" disabled>Повернуть ↻</button>
+        </div>
+        <p id="action-hint" class="panel__hint">Выберите свою фигуру, чтобы увидеть доступные ходы.</p>
+      </section>
 
-          <div class="player-card" data-player="dusk">
-            <header class="player-card__header">
-              <div class="player-card__crest" aria-hidden="true"></div>
-              <div>
-                <h3>Клан Сумрака</h3>
-                <p class="player-card__tagline">Прессингует аккуратно и расставляет ловушки.</p>
-              </div>
-              <span id="turn-dusk" class="player-card__turn" aria-live="polite">Ожидает</span>
-            </header>
-            <div class="player-card__body">
-              <p class="player-card__label">Трофеи</p>
-              <div id="captured-dusk" class="captured" aria-label="Захвачено Кланом Сумрака"></div>
-            </div>
-          </div>
-        </section>
+      <section class="panel">
+        <h2>Легенда орденов</h2>
+        <ul class="legend">
+          <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
+          <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
+          <li><span class="legend__glyph legend__glyph--light">◒</span> Зеркало (отражает луч под 90°)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛬</span> Оберег (двойное зеркало, меняется местами с соседями)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛨</span> Щитоносец (щит отражает луч)</li>
+          <li><span class="legend__glyph legend__glyph--light">▲</span> Тотем (поглощает удар)</li>
+        </ul>
+      </section>
 
-        <section class="panel panel--focus">
-          <h2 class="panel__title">Досье фигуры</h2>
-          <article id="piece-focus" class="focus-card focus-card--empty" aria-live="polite">
-            <div class="focus-card__glyph" id="focus-glyph" aria-hidden="true">☆</div>
-            <div class="focus-card__text">
-              <h3 id="focus-name">Выберите фигуру, чтобы узнать её сильные стороны</h3>
-              <p id="focus-role"></p>
-              <p id="focus-summary"></p>
-              <p id="focus-movement" class="focus-card__movement"></p>
-              <p id="focus-position" class="focus-card__position"></p>
-              <p id="focus-status" class="focus-card__status"></p>
-              <p id="focus-promotion" class="focus-card__promotion"></p>
-            </div>
-            <div class="focus-card__traits">
-              <h4>Специализация</h4>
-              <ul id="focus-traits" class="tag-list"></ul>
-            </div>
-            <div class="focus-card__stats">
-              <h4>Параметры</h4>
-              <dl id="focus-stats" class="stat-list"></dl>
-            </div>
-          </article>
-        </section>
+      <section class="panel">
+        <h2>Хроника</h2>
+        <ol id="move-log" class="log" aria-live="polite"></ol>
+      </section>
+    </aside>
 
-        <section class="panel panel--codex">
-          <h2 class="panel__title">Кодекс фигур</h2>
-          <p class="panel__subtitle">Сила и роль каждого юнита</p>
-          <div id="codex" class="codex"></div>
-        </section>
-
-        <section class="panel panel--rules">
-          <h2 class="panel__title">Правила сражения</h2>
-          <ul class="rules">
-            <li>Игроки ходят по очереди, начиная с Ордена Рассвета.</li>
-            <li>Нельзя оставлять своего Командора под атакой после собственного хода.</li>
-            <li>Фигура берёт противника, если заканчивает ход на его клетке.</li>
-            <li>Рекруты, достигнув последней линии врага, повышаются до Странника.</li>
-            <li>Победа наступает при пленении Командора соперника или при мате. Если ходов нет и угрозы тоже — объявляется перемирие.</li>
-          </ul>
-        </section>
-      </aside>
-    </div>
+    <section class="board-area">
+      <div class="board-wrapper">
+        <div id="board" class="board" role="grid" aria-label="Поле лучезарной сечи"></div>
+        <div id="laser-overlay" class="laser-overlay" aria-hidden="true"></div>
+        <div id="endgame" class="endgame" hidden>
+          <h2 id="endgame-title"></h2>
+          <p id="endgame-subtitle"></p>
+          <button type="button" id="play-again" class="button button--primary">Сыграть ещё раз</button>
+        </div>
+      </div>
+      <p id="status" class="status" aria-live="assertive"></p>
+    </section>
   </main>
-  <span class="sr-only" id="live-region" role="status" aria-live="assertive"></span>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,733 +1,302 @@
 :root {
   color-scheme: dark;
-  --bg: radial-gradient(circle at 20% 20%, #182347 0%, #0a0f1f 55%, #050812 100%);
-  --panel-bg: rgba(12, 22, 45, 0.79);
-  --panel-border: rgba(120, 167, 255, 0.2);
-  --text-primary: #dde7ff;
-  --text-muted: #94a3c7;
-  --accent-dawn: #f6d47f;
-  --accent-dusk: #7aa5ff;
-  --accent-neutral: rgba(255, 255, 255, 0.08);
-  --cell-light: linear-gradient(145deg, rgba(95, 130, 197, 0.35), rgba(26, 42, 74, 0.7));
-  --cell-dark: linear-gradient(145deg, rgba(18, 30, 56, 0.9), rgba(11, 19, 33, 0.95));
-  --highlight-move: rgba(134, 215, 255, 0.35);
-  --highlight-capture: rgba(255, 126, 158, 0.42);
-  --highlight-selected: rgba(255, 255, 255, 0.65);
-  --highlight-check: rgba(255, 182, 92, 0.55);
-  --focus-shadow: 0 18px 40px rgba(5, 8, 20, 0.55);
-  font-family: "Segoe UI", "Roboto", "Nunito", sans-serif;
+  --bg: #0f1417;
+  --bg-panel: #161d22;
+  --accent-light: #ffd166;
+  --accent-dark: #6b9aff;
+  --text: #f0f6ff;
+  --muted: #95a4b7;
+  --grid-line: rgba(255, 255, 255, 0.08);
+  --laser: #ff5e5e;
+  font-family: "Montserrat", "Segoe UI", sans-serif;
 }
 
-*, *::before, *::after {
+* {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
-  color: var(--text-primary);
+  background: radial-gradient(circle at top left, rgba(255, 220, 128, 0.05), transparent 40%),
+              radial-gradient(circle at bottom right, rgba(120, 180, 255, 0.07), transparent 35%),
+              var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
 }
 
-button {
-  font: inherit;
+.game {
+  width: min(1200px, 100%);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 320px 1fr;
 }
 
-.shell {
-  max-width: 1220px;
-  margin: 0 auto;
-  padding: clamp(16px, 4vw, 40px);
+.sidebar {
   display: flex;
   flex-direction: column;
-  gap: clamp(20px, 4vw, 32px);
+  gap: 1rem;
 }
 
-.hero {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: clamp(16px, 4vw, 40px);
-  background: linear-gradient(145deg, rgba(35, 58, 112, 0.38), rgba(9, 15, 28, 0.85));
-  border: 1px solid rgba(140, 180, 255, 0.2);
-  border-radius: 28px;
-  padding: clamp(18px, 4vw, 32px);
-  box-shadow: 0 25px 60px rgba(4, 9, 28, 0.5);
+.sidebar__hero {
+  background: linear-gradient(135deg, rgba(255, 209, 102, 0.35), rgba(107, 154, 255, 0.2));
+  border-radius: 18px;
+  padding: 1.5rem;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
 }
 
-.hero__text {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.hero__overtitle {
+.sidebar__overtitle {
   text-transform: uppercase;
-  letter-spacing: 0.3em;
   font-size: 0.75rem;
-  color: rgba(198, 212, 255, 0.7);
-  margin: 0;
+  letter-spacing: 0.18em;
+  margin: 0 0 0.5rem;
+  color: var(--accent-light);
 }
 
-.hero h1 {
-  font-size: clamp(2.2rem, 4vw, 3rem);
+.sidebar__hero h1 {
   margin: 0;
-  line-height: 1.1;
+  font-size: 2rem;
 }
 
-.hero__subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  max-width: 38ch;
-  font-size: 1rem;
+.sidebar__intro {
+  margin: 0.5rem 0 1rem;
+  color: var(--muted);
   line-height: 1.5;
 }
 
-.hero__button {
-  align-self: stretch;
-  padding: 14px 24px;
+.panel {
+  background: var(--bg-panel);
   border-radius: 16px;
-  border: none;
-  color: #02030a;
-  font-weight: 700;
-  background: linear-gradient(135deg, #f6d47f, #ffd27a 30%, #ffb87d 100%);
-  box-shadow: 0 12px 30px rgba(255, 193, 107, 0.35);
-  cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.hero__button:hover,
-.hero__button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 36px rgba(255, 193, 107, 0.4);
+.panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
 }
 
-.layout {
+.panel__turn {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panel__hint {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.legend {
+  margin: 0;
+  padding-left: 1rem;
   display: grid;
-  grid-template-columns: minmax(360px, 1.15fr) minmax(260px, 0.85fr);
-  gap: clamp(18px, 4vw, 32px);
-  align-items: start;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.legend__glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+  background: rgba(255, 209, 102, 0.15);
+}
+
+.legend__glyph--light {
+  color: var(--accent-light);
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent-light), rgba(255, 138, 76, 0.95));
+  color: #221400;
 }
 
 .board-area {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(18px, 3vw, 28px);
+  align-items: center;
+  gap: 1rem;
 }
 
-.board-frame {
+.board-wrapper {
   position: relative;
-  padding: clamp(12px, 3vw, 18px);
-  border-radius: 28px;
-  background: linear-gradient(150deg, rgba(48, 78, 143, 0.45), rgba(13, 21, 38, 0.9));
-  border: 1px solid rgba(142, 186, 255, 0.18);
-  box-shadow: 0 20px 55px rgba(6, 8, 20, 0.6);
 }
 
 .board {
-  --board-size: 6;
   display: grid;
-  grid-template-columns: repeat(var(--board-size), minmax(52px, 1fr));
-  gap: clamp(6px, 1.4vw, 10px);
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  width: min(600px, 90vw);
+  aspect-ratio: 10 / 8;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
 }
 
 .cell {
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  aspect-ratio: 1 / 1;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  color: inherit;
-  padding: 0;
-  background: var(--cell-light);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background: rgba(15, 20, 23, 0.9);
+  display: grid;
+  place-items: center;
+  font-size: clamp(1.5rem, 2.4vw, 2.4rem);
+  line-height: 1;
+  border: 1px solid var(--grid-line);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.cell--dark {
-  background: var(--cell-dark);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+.cell:nth-child(even) {
+  background: rgba(12, 18, 22, 0.9);
 }
 
-.cell:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(6, 10, 26, 0.4);
+.cell--light {
+  background: rgba(36, 43, 48, 0.95);
 }
 
-.cell:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
-  outline-offset: 2px;
+.cell--selected {
+  outline: 3px solid var(--accent-light);
+  outline-offset: -3px;
 }
 
-.cell::after {
+.cell--option::after {
   content: "";
   position: absolute;
-  inset: 10%;
-  border-radius: 16px;
-  opacity: 0;
-  transform: scale(0.9);
-  transition: opacity 0.15s ease, transform 0.2s ease;
-}
-
-.cell--selected::after {
-  background: var(--highlight-selected);
-  opacity: 0.4;
-  transform: scale(1);
-}
-
-.cell--move::after {
-  background: var(--highlight-move);
-  opacity: 0.65;
-  transform: scale(1);
+  inset: 20%;
+  border-radius: 12px;
+  border: 2px dashed var(--accent-dark);
+  background: rgba(107, 154, 255, 0.18);
 }
 
 .cell--capture::after {
-  background: var(--highlight-capture);
-  opacity: 0.8;
-  transform: scale(1);
+  border-style: solid;
+  background: rgba(255, 94, 94, 0.25);
+  border-color: var(--laser);
 }
 
-.cell--alert::after {
-  background: var(--highlight-check);
-  opacity: 0.9;
-  transform: scale(1);
-  box-shadow: 0 0 18px rgba(255, 182, 92, 0.8);
+.cell--laser-trace {
+  box-shadow: inset 0 0 0 3px rgba(255, 94, 94, 0.6);
 }
 
 .piece {
-  width: 72%;
-  height: 72%;
-  border-radius: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  backdrop-filter: blur(4px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22), 0 10px 25px rgba(0, 0, 0, 0.45);
-  transition: transform 0.18s ease;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.5);
 }
 
-.piece--dawn {
-  background: radial-gradient(circle at 30% 30%, rgba(255, 240, 200, 0.92), rgba(246, 212, 127, 0.95));
-  color: #331b05;
+.piece--light {
+  color: var(--accent-light);
 }
 
-.piece--dusk {
-  background: radial-gradient(circle at 30% 30%, rgba(220, 234, 255, 0.92), rgba(122, 165, 255, 0.96));
-  color: #081231;
+.piece--shadow {
+  color: var(--accent-dark);
 }
 
 .piece__glyph {
-  text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+  display: inline-block;
+  transition: transform 0.2s ease;
 }
 
 .status {
-  display: grid;
-  gap: 6px;
-  padding: 16px 20px;
-  background: linear-gradient(150deg, rgba(18, 28, 52, 0.85), rgba(10, 16, 31, 0.9));
-  border-radius: 18px;
-  border: 1px solid rgba(120, 167, 255, 0.2);
-  box-shadow: var(--focus-shadow);
-}
-
-.status p {
-  margin: 0;
-  font-size: 0.95rem;
-}
-
-.status p:first-child {
-  font-weight: 600;
-}
-
-.panel {
-  background: var(--panel-bg);
-  border-radius: 26px;
-  border: 1px solid var(--panel-border);
-  padding: clamp(16px, 3vw, 24px);
-  display: grid;
-  gap: clamp(14px, 3vw, 20px);
-  box-shadow: var(--focus-shadow);
-}
-
-.panel__title-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.panel__title {
-  margin: 0;
+  min-height: 2.5rem;
+  text-align: center;
   font-size: 1.1rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.panel__subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  line-height: 1.4;
-}
-
-.player-card {
-  position: relative;
-  background: linear-gradient(155deg, rgba(24, 38, 66, 0.9), rgba(9, 14, 24, 0.9));
-  border-radius: 22px;
-  padding: 16px;
-  border: 1px solid rgba(110, 160, 255, 0.18);
-  display: grid;
-  gap: 12px;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.player-card[data-player="dawn"] .player-card__crest {
-  background: radial-gradient(circle, rgba(246, 212, 127, 0.8), rgba(246, 212, 127, 0));
-}
-
-.player-card[data-player="dusk"] .player-card__crest {
-  background: radial-gradient(circle, rgba(122, 165, 255, 0.85), rgba(122, 165, 255, 0));
-}
-
-.player-card__header {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 14px;
-  align-items: center;
-}
-
-.player-card__crest {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
-}
-
-.player-card__tagline {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.82rem;
-}
-
-.player-card__turn {
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.player-card__body {
-  display: grid;
-  gap: 8px;
-}
-
-.player-card__label {
-  margin: 0;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(201, 211, 245, 0.7);
-}
-
-.captured {
-  min-height: 32px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.captured span {
-  padding: 6px 10px;
-  border-radius: 999px;
-  font-size: 0.9rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.captured span strong {
-  font-weight: 600;
-  color: #fff2c2;
-}
-
-.captured span span {
-  font-size: 1.1rem;
-}
-
-.captured__empty {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.player-card--active {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 38px rgba(10, 16, 34, 0.55);
-}
-
-.player-card--active .player-card__turn {
-  background: linear-gradient(135deg, rgba(246, 212, 127, 0.9), rgba(255, 184, 125, 0.9));
-  color: #1f1304;
-  border-color: rgba(255, 255, 255, 0.4);
-}
-
-.player-card--alert {
-  box-shadow: 0 22px 42px rgba(255, 136, 90, 0.35);
-}
-
-.player-card--alert .player-card__turn {
-  background: linear-gradient(135deg, rgba(255, 145, 98, 0.95), rgba(255, 99, 132, 0.85));
-  color: #2b0508;
-}
-
-.focus-card {
-  display: grid;
-  grid-template-columns: 80px 1fr;
-  gap: 16px;
-  align-items: start;
-  background: linear-gradient(155deg, rgba(19, 32, 58, 0.9), rgba(8, 12, 25, 0.95));
-  border-radius: 22px;
-  padding: 18px;
-  border: 1px solid rgba(130, 175, 255, 0.2);
-  position: relative;
-}
-
-.focus-card__glyph {
-  width: 80px;
-  height: 80px;
-  border-radius: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 2.4rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.focus-card__text {
-  display: grid;
-  gap: 8px;
-}
-
-.focus-card__text h3 {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.focus-card__text p {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.focus-card__movement {
-  color: #ffe6a8;
-}
-
-.focus-card__status {
-  color: #9bd0ff;
-}
-
-.focus-card__promotion {
-  color: #ffd4ba;
-}
-
-.focus-card__traits,
-.focus-card__stats {
-  grid-column: 1 / -1;
-}
-
-.focus-card__traits h4,
-.focus-card__stats h4 {
-  margin: 0 0 8px;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(206, 220, 255, 0.7);
-}
-
-.tag-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.tag-list li {
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  font-size: 0.78rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.tag-list__placeholder {
-  opacity: 0.5;
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.stat-list {
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px 12px;
-}
-
-.stat-list dt {
-  font-size: 0.78rem;
-  color: rgba(206, 220, 255, 0.7);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.stat-list dd {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.focus-card--empty {
-  background: linear-gradient(155deg, rgba(22, 33, 57, 0.7), rgba(7, 11, 24, 0.85));
-}
-
-.focus-card--empty .focus-card__glyph {
-  opacity: 0.4;
-}
-
-.codex {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.codex-card {
-  background: linear-gradient(155deg, rgba(27, 42, 74, 0.85), rgba(12, 20, 38, 0.9));
-  border-radius: 20px;
-  padding: 16px;
-  border: 1px solid rgba(128, 170, 255, 0.18);
-  display: grid;
-  gap: 12px;
-}
-
-.codex-card__header {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 12px;
-}
-
-.codex-card__glyph {
-  width: 46px;
-  height: 46px;
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.8rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.codex-card__title {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.codex-card__role {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.codex-card__text {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.rules {
-  margin: 0;
-  padding-left: 18px;
-  display: grid;
-  gap: 8px;
-  color: var(--text-muted);
-  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .log {
-  gap: 18px;
+  margin: 0;
+  padding-left: 1.5rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  max-height: 240px;
+  overflow: auto;
 }
 
-.move-log {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.actions {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  max-height: clamp(220px, 32vh, 320px);
-  overflow-y: auto;
-  scrollbar-width: thin;
-}
-
-.move-log::-webkit-scrollbar {
-  width: 6px;
-}
-
-.move-log::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-}
-
-.move-log__entry {
-  display: grid;
-  grid-template-columns: 36px 1fr;
-  align-items: start;
-  gap: 12px;
-  background: rgba(13, 21, 38, 0.75);
-  border-radius: 16px;
-  padding: 10px 14px;
-  border: 1px solid rgba(120, 167, 255, 0.18);
-}
-
-.move-log__turn {
-  font-weight: 700;
-  font-size: 1rem;
-  color: rgba(255, 255, 255, 0.82);
-}
-
-.move-log__row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(120px, 1fr));
-  gap: 8px;
-}
-
-.move-log__cell {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 8px 10px;
-  display: grid;
-  gap: 4px;
-}
-
-.move-log__cell--empty {
-  opacity: 0.4;
-  text-align: center;
-  padding: 12px;
-}
-
-.move-log__player {
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(203, 216, 255, 0.6);
-}
-
-.move-log__notation {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.move-log__detail {
-  margin: 0;
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .endgame {
   position: absolute;
-  inset: 0;
+  inset: 10%;
+  border-radius: 18px;
+  padding: 2rem;
+  background: rgba(15, 20, 23, 0.95);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
   display: grid;
+  gap: 1rem;
   place-items: center;
   text-align: center;
-  background: rgba(5, 8, 20, 0.92);
-  border-radius: inherit;
-  border: 1px solid rgba(246, 212, 127, 0.3);
-  backdrop-filter: blur(4px);
-  gap: 12px;
 }
 
-.endgame h2 {
-  margin: 0;
-  font-size: 1.8rem;
-}
-
-.endgame p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
-.endgame__button {
-  padding: 12px 24px;
-  border-radius: 14px;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  background: linear-gradient(135deg, #7aa5ff, #a3c2ff);
-  color: #06112b;
-  box-shadow: 0 12px 28px rgba(122, 165, 255, 0.35);
-}
-
-.sr-only {
+.laser-overlay {
+  pointer-events: none;
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+  inset: 0;
 }
 
-@media (max-width: 1050px) {
-  .layout {
+@media (max-width: 960px) {
+  .game {
     grid-template-columns: 1fr;
   }
 
-  .hero {
-    flex-direction: column;
-    align-items: stretch;
+  .sidebar {
+    order: 2;
   }
 
-  .hero__button {
-    align-self: flex-start;
-  }
-}
-
-@media (max-width: 720px) {
   .board {
-    grid-template-columns: repeat(var(--board-size), minmax(40px, 1fr));
-  }
-
-  .move-log__row {
-    grid-template-columns: 1fr;
+    width: 100%;
   }
 }
 
 @media (max-width: 540px) {
-  .focus-card {
-    grid-template-columns: 1fr;
-    text-align: left;
+  body {
+    padding: 0.5rem;
   }
 
-  .focus-card__glyph {
-    justify-self: flex-start;
+  .sidebar__hero h1 {
+    font-size: 1.6rem;
+  }
+
+  .panel, .sidebar__hero {
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous ability-driven ruleset with a streamlined two-player laser chess experience styled after Slavic mythology
- rebuild the UI around a compact sidebar, action controls, and a 10×8 laser board with visual feedback for selections, moves, and beam traces
- implement full laser optics with mirrors, shields, swaps, captures, logging, and victory detection tied to destroying the opposing волхв

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_690204e288e88320a338d9ffe8610b0f