### PR TITLE
Add

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,6 @@
         <p class="sidebar__overtitle">Дуэль лучезарных волхвов</p>
         <h1>Лучезарная сечь</h1>
         <p class="sidebar__intro">Поверните зеркала, направьте лучи Перуна и Чернобога и сразите чужого волхва, не подпуская свет к своему.</p>
-        <div class="hero__actions">
-          <button type="button" id="new-game" class="button button--primary">Новая партия</button>
-          <button type="button" id="theme-toggle" class="button button--ghost" aria-pressed="false">Светлая тема</button>
-        </div>
       </header>
 
       <section class="panel">
@@ -25,12 +21,14 @@
       </section>
 
       <section class="panel">
-        <h2>Действия</h2>
-        <div class="actions">
-          <button type="button" id="rotate-left" class="button" disabled>Повернуть ↺</button>
-          <button type="button" id="rotate-right" class="button" disabled>Повернуть ↻</button>
-        </div>
+        <h2>Подсказка</h2>
         <p id="action-hint" class="panel__hint">Выберите свою фигуру, чтобы увидеть доступные ходы.</p>
+      </section>
+
+      <section class="panel panel--piece" aria-live="polite">
+        <h2>Фигура</h2>
+        <p id="piece-name" class="piece-panel__name">—</p>
+        <p id="piece-details" class="piece-panel__details">Коснитесь своей фигуры, чтобы узнать её свойства.</p>
       </section>
 
       <section class="panel panel--legend">
@@ -45,13 +43,15 @@
         </ul>
       </section>
 
-      <section class="panel panel--log">
-        <h2>Хроника</h2>
-        <ol id="move-log" class="log" aria-live="polite"></ol>
-      </section>
     </aside>
 
     <section class="board-area">
+      <div class="board-toolbar">
+        <button type="button" id="new-game" class="toolbar-button toolbar-button--primary" title="Начать заново">New</button>
+        <button type="button" id="theme-toggle" class="toolbar-button toolbar-button--icon" aria-pressed="false" aria-label="Переключить тему">
+          <span aria-hidden="true">🌙</span>
+        </button>
+      </div>
       <div class="board-wrapper">
         <div id="board" class="board" role="grid" aria-label="Поле лучезарной сечи"></div>
         <div id="laser-overlay" class="laser-overlay" aria-hidden="true"></div>
@@ -60,6 +60,10 @@
           <p id="endgame-subtitle"></p>
           <button type="button" id="play-again" class="button button--primary">Сыграть ещё раз</button>
         </div>
+      </div>
+      <div class="board-actions">
+        <button type="button" id="rotate-left" class="board-action" disabled aria-label="Повернуть против часовой стрелки">↺</button>
+        <button type="button" id="rotate-right" class="board-action" disabled aria-label="Повернуть по часовой стрелке">↻</button>
       </div>
       <p id="status" class="status" aria-live="assertive"></p>
     </section>

--- a/index.html
+++ b/index.html
@@ -47,10 +47,9 @@
         <ul class="legend">
           <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
           <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
-          <li><span class="legend__glyph legend__glyph--light">◒</span> Зеркало (отражает луч под 90°)</li>
-          <li><span class="legend__glyph legend__glyph--light">⛬</span> Оберег (двойное зеркало, меняется местами с соседями)</li>
-          <li><span class="legend__glyph legend__glyph--light">⛨</span> Щитоносец (щит отражает луч)</li>
-          <li><span class="legend__glyph legend__glyph--light">▲</span> Тотем (поглощает удар)</li>
+          <li><span class="legend__glyph legend__glyph--light">◩</span> Зерцало (одна отражающая грань)</li>
+          <li><span class="legend__glyph legend__glyph--light">🛡</span> Щитоносец (останавливает луч щитом)</li>
+          <li><span class="legend__glyph legend__glyph--light">⟁</span> Тотем (двойное зерцало, меняется местами с союзниками)</li>
         </ul>
       </section>
     </aside>

--- a/index.html
+++ b/index.html
@@ -8,43 +8,6 @@
 </head>
 <body class="theme-dark">
   <main class="game">
-    <aside class="sidebar">
-      <header class="sidebar__hero">
-        <p class="sidebar__overtitle">Дуэль лучезарных волхвов</p>
-        <h1>Лучезарная сечь</h1>
-        <p class="sidebar__intro">Поверните зеркала, направьте лучи Перуна и Чернобога и сразите чужого волхва, не подпуская свет к своему.</p>
-      </header>
-
-      <section class="panel">
-        <h2>Ход</h2>
-        <p id="turn-indicator" class="panel__turn">—</p>
-      </section>
-
-      <section class="panel">
-        <h2>Подсказка</h2>
-        <p id="action-hint" class="panel__hint">Выберите свою фигуру, чтобы увидеть доступные ходы.</p>
-      </section>
-
-      <section class="panel panel--piece" aria-live="polite">
-        <h2>Фигура</h2>
-        <p id="piece-name" class="piece-panel__name">—</p>
-        <p id="piece-details" class="piece-panel__details">Коснитесь своей фигуры, чтобы узнать её свойства.</p>
-      </section>
-
-      <section class="panel panel--legend">
-        <h2>Легенда орденов</h2>
-        <ul class="legend">
-          <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
-          <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
-          <li><span class="legend__glyph legend__glyph--light">◒</span> Зеркало (отражает луч под 90°)</li>
-          <li><span class="legend__glyph legend__glyph--light">⛬</span> Оберег (двойное зеркало, меняется местами с соседями)</li>
-          <li><span class="legend__glyph legend__glyph--light">⛨</span> Щитоносец (щит отражает луч)</li>
-          <li><span class="legend__glyph legend__glyph--light">▲</span> Тотем (поглощает удар)</li>
-        </ul>
-      </section>
-
-    </aside>
-
     <section class="board-area">
       <div class="board-toolbar">
         <button type="button" id="new-game" class="toolbar-button toolbar-button--primary" title="Начать заново">New</button>
@@ -67,6 +30,30 @@
       </div>
       <p id="status" class="status" aria-live="assertive"></p>
     </section>
+    <aside class="sidebar">
+      <section class="panel">
+        <h2>Ход</h2>
+        <p id="turn-indicator" class="panel__turn">—</p>
+      </section>
+
+      <section class="panel panel--piece" aria-live="polite">
+        <h2>Фигура</h2>
+        <p id="piece-name" class="piece-panel__name">—</p>
+        <p id="piece-details" class="piece-panel__details">Коснитесь своей фигуры, чтобы узнать её свойства.</p>
+      </section>
+
+      <section class="panel panel--legend">
+        <h2>Легенда орденов</h2>
+        <ul class="legend">
+          <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
+          <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
+          <li><span class="legend__glyph legend__glyph--light">◒</span> Зеркало (отражает луч под 90°)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛬</span> Оберег (двойное зеркало, меняется местами с соседями)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛨</span> Щитоносец (щит отражает луч)</li>
+          <li><span class="legend__glyph legend__glyph--light">▲</span> Тотем (поглощает удар)</li>
+        </ul>
+      </section>
+    </aside>
   </main>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -2,125 +2,69 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Астральный двор —  стратегов</title>
+  <title>Лучезарная сечь</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <main class="shell">
-    <header class="hero">
-      <div class="hero__text">
-        <p class="hero__overtitle">Тактическая дуэль на двоих</p>
-        <h1>Астральный двор</h1>
-        <p class="hero__subtitle">Управляйте эскадрами Орденов Рассвета и Сумрака, командуйте уникальными фигурами и переграйте соперника в поединке света и тени.</p>
-      </div>
-      <button type="button" id="new-game" class="hero__button">Новая партия</button>
-    </header>
-
-    <div class="layout">
-      <section class="board-area">
-        <div class="board-frame">
-          <div id="board" class="board" role="grid" aria-label="Игровое поле Астрального двора"></div>
-          <div id="endgame" class="endgame" aria-live="assertive" hidden>
-            <h2 id="endgame-title"></h2>
-            <p id="endgame-subtitle"></p>
-            <button type="button" id="play-again" class="endgame__button">Сыграть ещё</button>
-          </div>
+<body class="theme-dark">
+  <main class="game">
+    <aside class="sidebar">
+      <header class="sidebar__hero">
+        <p class="sidebar__overtitle">Дуэль лучезарных волхвов</p>
+        <h1>Лучезарная сечь</h1>
+        <p class="sidebar__intro">Поверните зеркала, направьте лучи Перуна и Чернобога и сразите чужого волхва, не подпуская свет к своему.</p>
+        <div class="hero__actions">
+          <button type="button" id="new-game" class="button button--primary">Новая партия</button>
+          <button type="button" id="theme-toggle" class="button button--ghost" aria-pressed="false">Светлая тема</button>
         </div>
+      </header>
 
-        <div id="status" class="status" role="status" aria-live="polite">
-          <p id="status-primary"></p>
-          <p id="status-secondary"></p>
-        </div>
-
-        <section class="log panel">
-          <div class="panel__title-row">
-            <h2 class="panel__title">Летопись ходов</h2>
-            <p class="panel__subtitle">Отслеживайте развитие дуэли по ходам</p>
-          </div>
-          <ol id="move-log" class="move-log" aria-live="polite"></ol>
-        </section>
+      <section class="panel">
+        <h2>Ход</h2>
+        <p id="turn-indicator" class="panel__turn">—</p>
       </section>
 
-      <aside class="hud">
-        <section class="panel panel--players">
-          <h2 class="panel__title">Командование</h2>
-          <p class="panel__subtitle">Выберите фигуру своего ордена, чтобы вывести её характеристики.</p>
-          <div class="player-card" data-player="dawn">
-            <header class="player-card__header">
-              <div class="player-card__crest" aria-hidden="true"></div>
-              <div>
-                <h3>Орден Рассвета</h3>
-                <p class="player-card__tagline">Атакует молниеносно и удерживает пространство.</p>
-              </div>
-              <span id="turn-dawn" class="player-card__turn" aria-live="polite">Ход</span>
-            </header>
-            <div class="player-card__body">
-              <p class="player-card__label">Трофеи</p>
-              <div id="captured-dawn" class="captured" aria-label="Захвачено Орденом Рассвета"></div>
-            </div>
-          </div>
+      <section class="panel">
+        <h2>Действия</h2>
+        <div class="actions">
+          <button type="button" id="rotate-left" class="button" disabled>Повернуть ↺</button>
+          <button type="button" id="rotate-right" class="button" disabled>Повернуть ↻</button>
+        </div>
+        <p id="action-hint" class="panel__hint">Выберите свою фигуру, чтобы увидеть доступные ходы.</p>
+      </section>
 
-          <div class="player-card" data-player="dusk">
-            <header class="player-card__header">
-              <div class="player-card__crest" aria-hidden="true"></div>
-              <div>
-                <h3>Клан Сумрака</h3>
-                <p class="player-card__tagline">Прессингует аккуратно и расставляет ловушки.</p>
-              </div>
-              <span id="turn-dusk" class="player-card__turn" aria-live="polite">Ожидает</span>
-            </header>
-            <div class="player-card__body">
-              <p class="player-card__label">Трофеи</p>
-              <div id="captured-dusk" class="captured" aria-label="Захвачено Кланом Сумрака"></div>
-            </div>
-          </div>
-        </section>
+      <section class="panel panel--legend">
+        <h2>Легенда орденов</h2>
+        <ul class="legend">
+          <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
+          <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
+          <li><span class="legend__glyph legend__glyph--light">◒</span> Зеркало (отражает луч под 90°)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛬</span> Оберег (двойное зеркало, меняется местами с соседями)</li>
+          <li><span class="legend__glyph legend__glyph--light">⛨</span> Щитоносец (щит отражает луч)</li>
+          <li><span class="legend__glyph legend__glyph--light">▲</span> Тотем (поглощает удар)</li>
+        </ul>
+      </section>
 
-        <section class="panel panel--focus">
-          <h2 class="panel__title">Досье фигуры</h2>
-          <article id="piece-focus" class="focus-card focus-card--empty" aria-live="polite">
-            <div class="focus-card__glyph" id="focus-glyph" aria-hidden="true">☆</div>
-            <div class="focus-card__text">
-              <h3 id="focus-name">Выберите фигуру, чтобы узнать её сильные стороны</h3>
-              <p id="focus-role"></p>
-              <p id="focus-summary"></p>
-              <p id="focus-movement" class="focus-card__movement"></p>
-              <p id="focus-position" class="focus-card__position"></p>
-              <p id="focus-status" class="focus-card__status"></p>
-              <p id="focus-promotion" class="focus-card__promotion"></p>
-            </div>
-            <div class="focus-card__traits">
-              <h4>Специализация</h4>
-              <ul id="focus-traits" class="tag-list"></ul>
-            </div>
-            <div class="focus-card__stats">
-              <h4>Параметры</h4>
-              <dl id="focus-stats" class="stat-list"></dl>
-            </div>
-          </article>
-        </section>
+      <section class="panel panel--log">
+        <h2>Хроника</h2>
+        <ol id="move-log" class="log" aria-live="polite"></ol>
+      </section>
+    </aside>
 
-        <section class="panel panel--codex">
-          <h2 class="panel__title">Кодекс фигур</h2>
-          <p class="panel__subtitle">Сила и роль каждого юнита</p>
-          <div id="codex" class="codex"></div>
-        </section>
-
-        <section class="panel panel--rules">
-          <h2 class="panel__title">Правила сражения</h2>
-          <ul class="rules">
-            <li>Игроки ходят по очереди, начиная с Ордена Рассвета.</li>
-            <li>Нельзя оставлять своего Командора под атакой после собственного хода.</li>
-            <li>Фигура берёт противника, если заканчивает ход на его клетке.</li>
-            <li>Рекруты, достигнув последней линии врага, повышаются до Странника.</li>
-            <li>Победа наступает при пленении Командора соперника или при мате. Если ходов нет и угрозы тоже — объявляется перемирие.</li>
-          </ul>
-        </section>
-      </aside>
-    </div>
+    <section class="board-area">
+      <div class="board-wrapper">
+        <div id="board" class="board" role="grid" aria-label="Поле лучезарной сечи"></div>
+        <div id="laser-overlay" class="laser-overlay" aria-hidden="true"></div>
+        <div id="endgame" class="endgame" hidden>
+          <h2 id="endgame-title"></h2>
+          <p id="endgame-subtitle"></p>
+          <button type="button" id="play-again" class="button button--primary">Сыграть ещё раз</button>
+        </div>
+      </div>
+      <p id="status" class="status" aria-live="assertive"></p>
+    </section>
   </main>
-  <span class="sr-only" id="live-region" role="status" aria-live="assertive"></span>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -21,36 +21,42 @@ const PIECE_DEFS = {
     name: "Лучезар",
     glyph: "☼",
     canRotate: true,
+    description: "Излучает луч. Не двигается, но может поворачивать направление луча.",
     movement: () => []
   },
   volhv: {
     name: "Волхв",
     glyph: "✧",
     canRotate: false,
+    description: "Главная фигура. Двигается по прямым на одну клетку. Потеря ведёт к поражению.",
     movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
   },
   pyramid: {
     name: "Зеркало",
     glyph: "◒",
     canRotate: true,
+    description: "Один отражающий фас. Поворачивайте, чтобы направлять луч под прямым углом.",
     movement: (board, x, y, piece) => diagonalMoves(board, x, y, piece)
   },
   scarab: {
     name: "Оберег",
     glyph: "⛬",
     canRotate: true,
+    description: "Двойное зеркало. Может меняться местами с соседями или отражать с двух сторон.",
     movement: (board, x, y, piece) => scarabMoves(board, x, y, piece)
   },
   anubis: {
     name: "Щитоносец",
     glyph: "⛨",
     canRotate: true,
+    description: "Щит отражает луч с одной стороны. Защищайте волхва и зеркала.",
     movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
   },
   obelisk: {
     name: "Тотем",
     glyph: "▲",
     canRotate: false,
+    description: "Прочно стоит, блокирует луч. Может шагать по прямым.",
     movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
   }
 };
@@ -97,7 +103,6 @@ let currentPlayer = "light";
 let selectedCell = null;
 let currentOptions = [];
 let turnCounter = 1;
-let lastLaserPath = [];
 let currentTheme = "dark";
 
 const elements = {
@@ -107,13 +112,14 @@ const elements = {
   rotateLeft: document.getElementById("rotate-left"),
   rotateRight: document.getElementById("rotate-right"),
   hint: document.getElementById("action-hint"),
-  log: document.getElementById("move-log"),
   endgame: document.getElementById("endgame"),
   endgameTitle: document.getElementById("endgame-title"),
   endgameSubtitle: document.getElementById("endgame-subtitle"),
   playAgain: document.getElementById("play-again"),
   themeToggle: document.getElementById("theme-toggle"),
-  laserOverlay: document.getElementById("laser-overlay")
+  laserOverlay: document.getElementById("laser-overlay"),
+  pieceName: document.getElementById("piece-name"),
+  pieceDetails: document.getElementById("piece-details")
 };
 
 const cells = [];
@@ -129,9 +135,7 @@ function startNewGame() {
   currentPlayer = "light";
   selectedCell = null;
   currentOptions = [];
-  lastLaserPath = [];
   turnCounter = 1;
-  clearLog();
   clearLaserPath();
   updateTurnIndicator();
   renderBoard();
@@ -140,6 +144,7 @@ function startNewGame() {
   elements.endgame.hidden = true;
   elements.endgame.setAttribute("aria-hidden", "true");
   updateRotateControls(false);
+  updatePiecePanel();
 }
 
 function createEmptyBoard() {
@@ -268,6 +273,7 @@ function selectCell(x, y) {
       : "Для этой фигуры доступных действий нет.";
   elements.hint.textContent = `${def.name}: ${movesText}`;
   setStatus(`${PLAYERS[currentPlayer].name}: выбрана фигура ${def.name} на ${toNotation(x, y)}.`);
+  updatePiecePanel(piece, toNotation(x, y));
 }
 
 function clearSelection() {
@@ -276,6 +282,7 @@ function clearSelection() {
   renderBoard();
   updateRotateControls(false);
   elements.hint.textContent = "Выберите свою фигуру, чтобы увидеть доступные ходы.";
+  updatePiecePanel();
 }
 
 function updateRotateControls(enabled) {
@@ -286,25 +293,20 @@ function updateRotateControls(enabled) {
 }
 
 function executeMove(option, piece, from) {
-  const fromNotation = toNotation(from.x, from.y);
   const targetPiece = board[option.y][option.x];
 
   if (option.swap && targetPiece) {
     board[from.y][from.x] = targetPiece;
     board[option.y][option.x] = piece;
     setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} меняется местами с ${PIECE_DEFS[targetPiece.type].name} на ${toNotation(option.x, option.y)}.`);
-    logAction(`${PIECE_DEFS[piece.type].name} ${fromNotation} ↔ ${toNotation(option.x, option.y)}`);
   } else {
     board[from.y][from.x] = null;
     board[option.y][option.x] = piece;
-    let actionText = `${PIECE_DEFS[piece.type].name} ${fromNotation} → ${toNotation(option.x, option.y)}`;
     if (targetPiece) {
-      actionText += ` (захват ${PIECE_DEFS[targetPiece.type].name})`;
       setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} захватывает ${PIECE_DEFS[targetPiece.type].name}.`);
     } else {
       setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} перемещён на ${toNotation(option.x, option.y)}.`);
     }
-    logAction(actionText);
   }
 
   endTurn();
@@ -320,7 +322,6 @@ function rotateSelected(delta) {
   renderBoard();
   const dirSymbol = delta > 0 ? "↻" : "↺";
   setStatus(`${PLAYERS[currentPlayer].name}: ${def.name} на ${toNotation(selectedCell.x, selectedCell.y)} повёрнут ${delta > 0 ? "по" : "против"} часовой стрелки.`);
-  logAction(`${def.name} ${toNotation(selectedCell.x, selectedCell.y)} ${dirSymbol}`);
   endTurn();
 }
 
@@ -334,7 +335,6 @@ function endTurn() {
     const owner = PLAYERS[hitPiece.player].name;
     const pieceName = PIECE_DEFS[hitPiece.type].name;
     const cell = toNotation(laserResult.hit.x, laserResult.hit.y);
-    logAction(`Лазер поражает ${pieceName} (${owner}) на ${cell}`);
     setStatus(`${laserResult.firer} испепеляет ${pieceName} (${owner}) на ${cell}.`);
     if (hitPiece.type === "volhv") {
       finishGame(currentPlayer);
@@ -344,7 +344,6 @@ function endTurn() {
     const blockPiece = laserResult.blocked.piece;
     const owner = PLAYERS[blockPiece.player].name;
     const cell = toNotation(laserResult.blocked.x, laserResult.blocked.y);
-    logAction(`Луч останавливается о ${PIECE_DEFS[blockPiece.type].name} (${owner}) на ${cell}`);
     setStatus(`${laserResult.firer} не проходит через ${PIECE_DEFS[blockPiece.type].name} на ${cell}.`);
   }
   currentPlayer = currentPlayer === "light" ? "shadow" : "light";
@@ -500,22 +499,10 @@ function highlightLaserPath(result) {
     return;
   }
 
-  const path = result.path || [];
-  lastLaserPath = path;
-  for (const step of path) {
-    const cell = cells[step.y][step.x];
-    cell.classList.add("cell--laser-trace");
-  }
-
   drawLaserBeam(result);
 }
 
 function clearLaserPath() {
-  for (const step of lastLaserPath) {
-    const cell = cells[step.y][step.x];
-    if (cell) cell.classList.remove("cell--laser-trace");
-  }
-  lastLaserPath = [];
   if (elements.laserOverlay) {
     elements.laserOverlay.replaceChildren();
   }
@@ -651,17 +638,6 @@ function setStatus(message) {
   elements.status.textContent = message;
 }
 
-function logAction(text) {
-  const item = document.createElement("li");
-  item.textContent = `${turnCounter}. ${PLAYERS[currentPlayer].name}: ${text}`;
-  elements.log.appendChild(item);
-  elements.log.scrollTop = elements.log.scrollHeight;
-}
-
-function clearLog() {
-  elements.log.innerHTML = "";
-}
-
 function initialiseTheme() {
   let theme = null;
   try {
@@ -689,14 +665,44 @@ function setTheme(theme) {
   document.body.classList.toggle("theme-dark", currentTheme === "dark");
   document.documentElement.style.colorScheme = currentTheme === "light" ? "light" : "dark";
   if (elements.themeToggle) {
-    const buttonLabel = currentTheme === "light" ? "Тёмная тема" : "Светлая тема";
-    elements.themeToggle.textContent = buttonLabel;
+    const icon = currentTheme === "light" ? "☀️" : "🌙";
+    elements.themeToggle.innerHTML = `<span aria-hidden="true">${icon}</span>`;
     elements.themeToggle.setAttribute("aria-pressed", currentTheme === "light" ? "true" : "false");
     elements.themeToggle.setAttribute("aria-label", `Переключить тему. Текущая тема: ${currentTheme === "light" ? "светлая" : "тёмная"}.`);
+    elements.themeToggle.setAttribute("title", currentTheme === "light" ? "Включить тёмную тему" : "Включить светлую тему");
   }
   try {
     localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
   } catch (err) {
     // игнорируем, если локальное хранилище недоступно
+  }
+}
+
+function updatePiecePanel(piece = null, position = null) {
+  if (!elements.pieceName || !elements.pieceDetails) return;
+  if (!piece) {
+    elements.pieceName.textContent = "—";
+    elements.pieceDetails.textContent = "Коснитесь своей фигуры, чтобы узнать её свойства.";
+    return;
+  }
+  const def = PIECE_DEFS[piece.type];
+  const owner = PLAYERS[piece.player].name;
+  const facing = orientationToText(piece.orientation);
+  elements.pieceName.textContent = `${def.name} • ${owner}`;
+  const positionText = position ? `Позиция ${position}. ` : "";
+  elements.pieceDetails.textContent = `${positionText}${def.description} Повернут ${facing}.`;
+}
+
+function orientationToText(orientation) {
+  switch (mod4(orientation)) {
+    case 0:
+      return "к северу";
+    case 1:
+      return "к востоку";
+    case 2:
+      return "к югу";
+    case 3:
+    default:
+      return "к западу";
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,901 +1,617 @@
-(function () {
-  const BOARD_SIZE = 6;
-  const COLUMN_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
-  const ROW_NUMBERS = [6, 5, 4, 3, 2, 1];
-  const directionByPlayer = { dawn: -1, dusk: 1 };
+const BOARD_WIDTH = 8;
+const BOARD_HEIGHT = 8;
+const FILES = "ABCDEFGH";
+const THEME_STORAGE_KEY = "laser-theme";
 
-  const PLAYERS = {
-    dawn: {
-      name: 'Орден Рассвеа',
-      motto: 'Инициатива света',
-      color: '#f6d47f'
-    },
-    dusk: {
-      name: 'Клан Сумрака',
-      motto: 'Тактика тени',
-      color: '#7aa5ff'
-    }
+const PLAYERS = {
+  light: {
+    name: "Дружина Перуна",
+    glyph: "☼",
+    laserName: "Лучезар Перуна"
+  },
+  shadow: {
+    name: "Полк Чернобога",
+    glyph: "☽",
+    laserName: "Луч Чернобога"
+  }
+};
+
+const PIECE_DEFS = {
+  laser: {
+    name: "Лучезар",
+    glyph: "☼",
+    canRotate: true,
+    movement: () => []
+  },
+  volhv: {
+    name: "Волхв",
+    glyph: "✧",
+    canRotate: false,
+    movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
+  },
+  pyramid: {
+    name: "Зеркало",
+    glyph: "◒",
+    canRotate: true,
+    movement: (board, x, y, piece) => diagonalMoves(board, x, y, piece)
+  },
+  scarab: {
+    name: "Оберег",
+    glyph: "⛬",
+    canRotate: true,
+    movement: (board, x, y, piece) => scarabMoves(board, x, y, piece)
+  },
+  anubis: {
+    name: "Щитоносец",
+    glyph: "⛨",
+    canRotate: true,
+    movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
+  },
+  obelisk: {
+    name: "Тотем",
+    glyph: "▲",
+    canRotate: false,
+    movement: (board, x, y, piece) => orthogonalMoves(board, x, y, piece)
+  }
+};
+
+const DIRECTIONS = [
+  { dx: 0, dy: -1 }, // вверх
+  { dx: 1, dy: 0 },  // вправо
+  { dx: 0, dy: 1 },  // вниз
+  { dx: -1, dy: 0 }  // влево
+];
+
+const DIAGONALS = [
+  { dx: 1, dy: -1 },
+  { dx: 1, dy: 1 },
+  { dx: -1, dy: -1 },
+  { dx: -1, dy: 1 }
+];
+
+const INITIAL_LIGHT_SETUP = [
+  { x: 0, y: 7, type: "laser", orientation: 1 },
+  { x: 1, y: 7, type: "pyramid", orientation: 1 },
+  { x: 2, y: 7, type: "scarab", orientation: 0 },
+  { x: 3, y: 7, type: "volhv", orientation: 0 },
+  { x: 4, y: 7, type: "anubis", orientation: 0 },
+  { x: 5, y: 7, type: "scarab", orientation: 2 },
+  { x: 6, y: 7, type: "pyramid", orientation: 2 },
+  { x: 7, y: 7, type: "obelisk", orientation: 0 },
+  { x: 0, y: 6, type: "pyramid", orientation: 1 },
+  { x: 1, y: 6, type: "anubis", orientation: 3 },
+  { x: 2, y: 6, type: "pyramid", orientation: 0 },
+  { x: 3, y: 6, type: "obelisk", orientation: 0 },
+  { x: 4, y: 6, type: "pyramid", orientation: 2 },
+  { x: 5, y: 6, type: "anubis", orientation: 1 },
+  { x: 6, y: 6, type: "pyramid", orientation: 3 },
+  { x: 7, y: 6, type: "pyramid", orientation: 2 },
+  { x: 0, y: 5, type: "pyramid", orientation: 0 },
+  { x: 2, y: 5, type: "obelisk", orientation: 0 },
+  { x: 5, y: 5, type: "obelisk", orientation: 0 },
+  { x: 7, y: 5, type: "pyramid", orientation: 2 }
+];
+
+let board = createEmptyBoard();
+let currentPlayer = "light";
+let selectedCell = null;
+let currentOptions = [];
+let turnCounter = 1;
+let lastLaserPath = [];
+let currentTheme = "dark";
+
+const elements = {
+  board: document.getElementById("board"),
+  status: document.getElementById("status"),
+  turn: document.getElementById("turn-indicator"),
+  rotateLeft: document.getElementById("rotate-left"),
+  rotateRight: document.getElementById("rotate-right"),
+  hint: document.getElementById("action-hint"),
+  log: document.getElementById("move-log"),
+  endgame: document.getElementById("endgame"),
+  endgameTitle: document.getElementById("endgame-title"),
+  endgameSubtitle: document.getElementById("endgame-subtitle"),
+  playAgain: document.getElementById("play-again"),
+  themeToggle: document.getElementById("theme-toggle")
+};
+
+const cells = [];
+
+initialiseBoardGrid();
+attachEventListeners();
+initialiseTheme();
+startNewGame();
+
+function startNewGame() {
+  board = createEmptyBoard();
+  placeInitialPieces();
+  currentPlayer = "light";
+  selectedCell = null;
+  currentOptions = [];
+  lastLaserPath = [];
+  turnCounter = 1;
+  clearLog();
+  updateTurnIndicator();
+  renderBoard();
+  setStatus("Выберите фигуру и передвиньте её либо поверните зеркало.");
+  elements.hint.textContent = "Выберите свою фигуру, чтобы увидеть доступные ходы.";
+  elements.endgame.hidden = true;
+  updateRotateControls(false);
+}
+
+function createEmptyBoard() {
+  return Array.from({ length: BOARD_HEIGHT }, () => Array(BOARD_WIDTH).fill(null));
+}
+
+function placeInitialPieces() {
+  for (const spec of INITIAL_LIGHT_SETUP) {
+    placePiece(spec, "light");
+    placePiece(mirrorSpec(spec), "shadow");
+  }
+}
+
+function placePiece(spec, player) {
+  const piece = {
+    type: spec.type,
+    player,
+    orientation: spec.orientation % 4
   };
+  board[spec.y][spec.x] = piece;
+}
 
-  const PIECES = {
-    commander: {
-      name: 'Командор',
-      glyph: { dawn: '♔', dusk: '♚' },
-      role: 'Лидер',
-      description: 'Центр координации отряда. Командор обеспечивает связь и не может быть потерян.',
-      movement: 'Ходит на одну клетку в любом направлении.',
-      traits: ['Лидер', 'Тактическая аура'],
-      stats: { Манёвр: '★☆☆', Контроль: '★★★★★', Защита: '★★★★' }
-    },
-    sentinel: {
-      name: 'Страж',
-      glyph: { dawn: '♖', dusk: '♜' },
-      role: 'Линейный контроль',
-      description: 'Стражи держат прямые коридоры и отрезают пути отступления.',
-      movement: 'Любое количество клеток по горизонтали или вертикали без прыжков.',
-      traits: ['Линии давления', 'Гарнизон'],
-      stats: { Манёвр: '★★★', Контроль: '★★★★', Сложность: '★★' }
-    },
-    strider: {
-      name: 'Странник',
-      glyph: { dawn: '♗', dusk: '♝' },
-      role: 'Диагональный манёвр',
-      description: 'Странники режут пространство по диагоналям и выстраивают дуги обхода.',
-      movement: 'Любое количество клеток по диагонали без прыжков.',
-      traits: ['Фланг', 'Позиционный прессинг'],
-      stats: { Манёвр: '★★★★', Контроль: '★★★', Сложность: '★★☆' }
-    },
-    lancer: {
-      name: 'Гонец',
-      glyph: { dawn: '♘', dusk: '♞' },
-      role: 'Манёвр через заслоны',
-      description: 'Гонец прыгает дугой, прорывается через заслоны и наносит внезапные удары.',
-      movement: 'Прыжок буквой «Г»: две клетки в одном направлении и одна в перпендикулярном.',
-      traits: ['Скачок', 'Атака из тыла'],
-      stats: { Манёвр: '★★★★★', Контроль: '★★', Сложность: '★★★' }
-    },
-    squire: {
-      name: 'Рекрут',
-      glyph: { dawn: '♙', dusk: '♟' },
-      role: 'Линия фронта',
-      description: 'Рекруты выстраивают фронт. Врага берут по диагонали и могут сделать стартовый рывок.',
-      movement: 'На одну клетку вперёд (две при первом ходе). Захватывает по диагонали. На последней линии повышается до Странника.',
-      traits: ['Гарнизон', 'Повышение'],
-      stats: { Манёвр: '★★', Контроль: '★★', Сложность: '★' }
-    }
+function mirrorSpec(spec) {
+  return {
+    x: BOARD_WIDTH - 1 - spec.x,
+    y: BOARD_HEIGHT - 1 - spec.y,
+    type: spec.type,
+    orientation: (spec.orientation + 2) % 4
   };
+}
 
-  const boardEl = document.getElementById('board');
-  const statusPrimaryEl = document.getElementById('status-primary');
-  const statusSecondaryEl = document.getElementById('status-secondary');
-  const moveLogEl = document.getElementById('move-log');
-  const codexEl = document.getElementById('codex');
-  const newGameButton = document.getElementById('new-game');
-  const playAgainButton = document.getElementById('play-again');
-  const liveRegion = document.getElementById('live-region');
-  const endgameEl = document.getElementById('endgame');
-  const endgameTitleEl = document.getElementById('endgame-title');
-  const endgameSubtitleEl = document.getElementById('endgame-subtitle');
-
-  const playerCards = {
-    dawn: document.querySelector('.player-card[data-player="dawn"]'),
-    dusk: document.querySelector('.player-card[data-player="dusk"]')
-  };
-  const turnBadges = {
-    dawn: document.getElementById('turn-dawn'),
-    dusk: document.getElementById('turn-dusk')
-  };
-  const capturedEls = {
-    dawn: document.getElementById('captured-dawn'),
-    dusk: document.getElementById('captured-dusk')
-  };
-
-  const focusEls = {
-    card: document.getElementById('piece-focus'),
-    glyph: document.getElementById('focus-glyph'),
-    name: document.getElementById('focus-name'),
-    role: document.getElementById('focus-role'),
-    summary: document.getElementById('focus-summary'),
-    movement: document.getElementById('focus-movement'),
-    position: document.getElementById('focus-position'),
-    status: document.getElementById('focus-status'),
-    promotion: document.getElementById('focus-promotion'),
-    traits: document.getElementById('focus-traits'),
-    stats: document.getElementById('focus-stats')
-  };
-
-  let board = [];
-  let cellElements = [];
-  let currentPlayer = 'dawn';
-  let selectedCell = null;
-  let legalMoves = [];
-  let legalMoveMap = new Map();
-  let capturedPieces = { dawn: [], dusk: [] };
-  let moveHistory = [];
-  let gameState = 'idle';
-  let winner = null;
-
-  newGameButton.addEventListener('click', startNewGame);
-  playAgainButton.addEventListener('click', startNewGame);
-
-  function start() {
-    buildBoardSkeleton();
-    populateCodex();
-    startNewGame();
-  }
-
-  function startNewGame() {
-    board = createInitialBoard();
-    currentPlayer = 'dawn';
-    selectedCell = null;
-    legalMoves = [];
-    legalMoveMap.clear();
-    capturedPieces = { dawn: [], dusk: [] };
-    moveHistory = [];
-    gameState = 'playing';
-    winner = null;
-    endgameEl.hidden = true;
-    renderBoard();
-    updateHighlights();
-    updateCaptured();
-    renderMoveLog();
-    updatePieceFocus(null);
-    updateTurnPanel();
-    updateStatus('Орден Рассвета начинает партию.', 'Выберите фигуру, чтобы совершить первый ход.');
-  }
-
-  function buildBoardSkeleton() {
-    boardEl.innerHTML = '';
-    boardEl.style.setProperty('--board-size', BOARD_SIZE);
-    cellElements = Array.from({ length: BOARD_SIZE }, () => []);
-
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const cell = document.createElement('button');
-        cell.type = 'button';
-        cell.className = `cell ${(row + col) % 2 === 0 ? 'cell--light' : 'cell--dark'}`;
-        cell.dataset.row = row;
-        cell.dataset.col = col;
-        cell.dataset.coord = toNotation(row, col);
-        cell.setAttribute('aria-label', `Клетка ${toNotation(row, col)}`);
-        cell.addEventListener('click', handleCellClick);
-        boardEl.appendChild(cell);
-        cellElements[row][col] = cell;
-      }
+function initialiseBoardGrid() {
+  elements.board.innerHTML = "";
+  for (let y = 0; y < BOARD_HEIGHT; y++) {
+    cells[y] = [];
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      const cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = "cell";
+      cell.dataset.x = x;
+      cell.dataset.y = y;
+      cell.setAttribute("role", "gridcell");
+      cell.setAttribute("aria-label", `${FILES[x]}${BOARD_HEIGHT - y}`);
+      elements.board.appendChild(cell);
+      cell.addEventListener("click", () => handleCellInteraction(x, y));
+      cells[y][x] = cell;
     }
   }
+}
 
-  function handleCellClick(event) {
-    if (gameState !== 'playing') {
-      return;
-    }
-
-    const cell = event.currentTarget;
-    const row = Number(cell.dataset.row);
-    const col = Number(cell.dataset.col);
-    const piece = board[row][col];
-
-    const key = `${row},${col}`;
-    const move = legalMoveMap.get(key);
-    if (move && selectedCell) {
-      executeMove(selectedCell.row, selectedCell.col, move);
-      return;
-    }
-
-    if (selectedCell && selectedCell.row === row && selectedCell.col === col) {
-      selectedCell = null;
-      setLegalMoves([]);
-      updateHighlights();
-      updatePieceFocus(null);
-      updateStatus(`${PLAYERS[currentPlayer].name} ожидает решения.`, 'Вы можете выбрать другую фигуру.');
-      return;
-    }
-
-    if (!piece) {
-      selectedCell = null;
-      setLegalMoves([]);
-      updateHighlights();
-      updatePieceFocus(null);
-      return;
-    }
-
-    updatePieceFocus(piece, row, col);
-
-    if (piece.owner !== currentPlayer) {
-      setLegalMoves([]);
-      selectedCell = null;
-      updateHighlights();
-      updateStatus(`${PLAYERS[currentPlayer].name} ходит.`, 'Вы можете только изучить фигуры соперника.');
-      return;
-    }
-
-    const moves = getLegalMoves(row, col);
-    selectedCell = { row, col };
-    setLegalMoves(moves);
-    updateHighlights();
-    if (moves.length === 0) {
-      updateStatus(`${PIECES[piece.type].name} заблокирован.`, 'Выберите другую фигуру для манёвра.');
-    } else {
-      const coords = moves.map((m) => toNotation(m.row, m.col)).join(', ');
-      updateStatus(`${PIECES[piece.type].name} готов к манёвру.`, `Доступные клетки: ${coords}.`);
-    }
+function attachEventListeners() {
+  document.getElementById("new-game").addEventListener("click", startNewGame);
+  elements.rotateLeft.addEventListener("click", () => rotateSelected(-1));
+  elements.rotateRight.addEventListener("click", () => rotateSelected(1));
+  elements.playAgain.addEventListener("click", startNewGame);
+  if (elements.themeToggle) {
+    elements.themeToggle.addEventListener("click", toggleTheme);
   }
+}
 
-  function executeMove(fromRow, fromCol, move) {
-    const piece = board[fromRow][fromCol];
-    if (!piece) {
-      return;
-    }
-
-    const target = board[move.row][move.col];
-    const originalType = piece.type;
-    const opponent = otherPlayer(piece.owner);
-    const notation = `${toNotation(fromRow, fromCol)} → ${toNotation(move.row, move.col)}`;
-
-    if (target) {
-      capturedPieces[piece.owner].push(target.type);
-    }
-
-    board[move.row][move.col] = piece;
-    board[fromRow][fromCol] = null;
-    piece.moved = true;
-
-    let promotionType = null;
-    if (move.promotion) {
-      promotionType = move.promotion;
-      piece.promotedFrom = piece.promotedFrom || piece.type;
-      piece.type = promotionType;
-    }
-
-    const moveEntry = {
-      player: piece.owner,
-      pieceType: originalType,
-      notation,
-      capture: Boolean(target),
-      promotion: promotionType,
-      check: false,
-      checkmate: false,
-      stalemate: false
-    };
-
-    const victoryByCapture = target && target.type === 'commander';
-
-    selectedCell = null;
-    setLegalMoves([]);
-    renderBoard();
-    updateCaptured();
-
-    if (victoryByCapture) {
-      moveEntry.checkmate = true;
-      moveHistory.push(moveEntry);
-      finalizeGame(piece.owner, `${PIECES[originalType].name} пленил Командора ${PLAYERS[opponent].name}.`, 'Решающее столкновение завершило поединок.');
-      return;
-    }
-
-    const opponentCommander = findCommander(board, opponent);
-    const givesCheck = opponentCommander ? isSquareUnderAttack(board, opponentCommander.row, opponentCommander.col, piece.owner) : false;
-    moveEntry.check = givesCheck;
-    moveHistory.push(moveEntry);
-
-    currentPlayer = opponent;
-
-    const opponentHasMoves = hasLegalMoves(board, opponent);
-    const opponentInCheck = isCommanderInCheck(board, opponent);
-
-    if (!opponentHasMoves) {
-      if (opponentInCheck) {
-        moveEntry.checkmate = true;
-        finalizeGame(piece.owner, `${PLAYERS[piece.owner].name} ставит мат.`, `${PLAYERS[opponent].name} не может спасти Командора.`);
-      } else {
-        moveEntry.stalemate = true;
-        finalizeGame(null, 'Перемирие — пат.', 'Оба ордена выдыхают и объявляют ничью.');
-      }
-      renderMoveLog();
-      return;
-    }
-
-    renderMoveLog();
-    updatePieceFocus(null);
-    updateTurnPanel();
-
-    const actorName = PLAYERS[piece.owner].name;
-    const opponentName = PLAYERS[opponent].name;
-    let primary = `${actorName} перемещает ${PIECES[originalType].name} на ${toNotation(move.row, move.col)}.`;
-    if (target) {
-      primary += ` Взято: ${PIECES[target.type].name}.`;
-    }
-    if (promotionType) {
-      primary += ` Повышение до ${PIECES[piece.type].name}.`;
-    }
-
-    let secondary;
-    if (givesCheck) {
-      secondary = `${opponentName}, ваш Командор под прицелом!`;
-    } else if (opponentInCheck) {
-      secondary = `${opponentName}, ваш Командор всё ещё под угрозой.`;
-    } else {
-      secondary = `${opponentName}, ваш ход.`;
-    }
-
-    updateStatus(primary, secondary);
-    updateHighlights();
-    updateCommanderAlerts();
-  }
-
-  function finalizeGame(winningPlayer, title, subtitle) {
-    gameState = 'ended';
-    winner = winningPlayer;
-    selectedCell = null;
-    setLegalMoves([]);
-    updateHighlights();
-    updateCommanderAlerts();
-    updateTurnPanel();
-
-    const heading = winningPlayer ? `${PLAYERS[winningPlayer].name} побеждает!` : title;
-    const detail = subtitle;
-
-    endgameTitleEl.textContent = heading;
-    endgameSubtitleEl.textContent = detail;
-    endgameEl.hidden = false;
-    updateStatus(heading, detail);
-    renderMoveLog();
-  }
-
-  function setLegalMoves(moves) {
-    legalMoves = moves;
-    legalMoveMap = new Map();
-    moves.forEach((move) => {
-      legalMoveMap.set(`${move.row},${move.col}`, move);
-    });
-  }
-
-  function renderBoard() {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const cell = cellElements[row][col];
-        const piece = board[row][col];
-        cell.innerHTML = '';
-        cell.classList.remove('cell--alert');
-        if (!piece) {
-          cell.setAttribute('aria-label', `Пустая клетка ${toNotation(row, col)}`);
-          continue;
-        }
-        const def = PIECES[piece.type];
-        const wrapper = document.createElement('div');
-        wrapper.className = `piece piece--${piece.owner} piece--${piece.type}`;
-        const glyph = document.createElement('span');
-        glyph.className = 'piece__glyph';
-        glyph.setAttribute('aria-hidden', 'true');
-        glyph.textContent = def.glyph[piece.owner];
-        const sr = document.createElement('span');
-        sr.className = 'sr-only';
-        sr.textContent = `${def.name} игрока ${PLAYERS[piece.owner].name}`;
+function renderBoard() {
+  clearLaserPath();
+  for (let y = 0; y < BOARD_HEIGHT; y++) {
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      const cell = cells[y][x];
+      const piece = board[y][x];
+      cell.classList.toggle("cell--light", (x + y) % 2 === 0);
+      cell.classList.toggle("cell--selected", selectedCell && selectedCell.x === x && selectedCell.y === y);
+      cell.classList.remove("cell--option", "cell--capture");
+      if (piece) {
+        const def = PIECE_DEFS[piece.type];
+        const wrapper = document.createElement("div");
+        wrapper.className = `piece piece--${piece.player}`;
+        const glyph = document.createElement("span");
+        glyph.textContent = def.glyph;
+        glyph.className = "piece__glyph";
+        glyph.style.transform = `rotate(${piece.orientation * 90}deg)`;
         wrapper.appendChild(glyph);
-        wrapper.appendChild(sr);
-        cell.appendChild(wrapper);
-        cell.setAttribute('aria-label', `${def.name} ${PLAYERS[piece.owner].name} на клетке ${toNotation(row, col)}`);
-      }
-    }
-    updateCommanderAlerts();
-  }
-
-  function updateHighlights() {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const cell = cellElements[row][col];
-        cell.classList.remove('cell--selected', 'cell--move', 'cell--capture');
-        if (selectedCell && selectedCell.row === row && selectedCell.col === col) {
-          cell.classList.add('cell--selected');
-        }
-        const key = `${row},${col}`;
-        if (legalMoveMap.has(key)) {
-          const move = legalMoveMap.get(key);
-          cell.classList.add(move.capture ? 'cell--capture' : 'cell--move');
-        }
-      }
-    }
-  }
-
-  function updateCommanderAlerts() {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        cellElements[row][col].classList.remove('cell--alert');
-      }
-    }
-    const players = ['dawn', 'dusk'];
-    players.forEach((player) => {
-      const commander = findCommander(board, player);
-      if (!commander) {
-        return;
-      }
-      const cell = cellElements[commander.row][commander.col];
-      if (isCommanderInCheck(board, player)) {
-        cell.classList.add('cell--alert');
-      }
-    });
-  }
-
-  function updateStatus(primary, secondary = '', announce = true) {
-    statusPrimaryEl.textContent = primary;
-    statusSecondaryEl.textContent = secondary;
-    if (announce) {
-      const combined = `${primary} ${secondary}`.trim();
-      liveRegion.textContent = combined;
-      window.setTimeout(() => {
-        liveRegion.textContent = '';
-      }, 1000);
-    }
-  }
-
-  function updateTurnPanel() {
-    const players = ['dawn', 'dusk'];
-    players.forEach((player) => {
-      const card = playerCards[player];
-      const badge = turnBadges[player];
-      card.classList.remove('player-card--active', 'player-card--alert');
-      if (gameState === 'ended') {
-        if (winner === player) {
-          badge.textContent = 'Победа';
-        } else if (winner === null) {
-          badge.textContent = 'Перемирие';
-        } else {
-          badge.textContent = 'Поражение';
-        }
-        return;
-      }
-      if (currentPlayer === player) {
-        badge.textContent = 'Ход';
-        card.classList.add('player-card--active');
+        wrapper.setAttribute("aria-label", `${def.name} (${PLAYERS[piece.player].name})`);
+        cell.replaceChildren(wrapper);
       } else {
-        badge.textContent = 'Ожидает';
+        cell.replaceChildren();
       }
-      if (isCommanderInCheck(board, player)) {
-        card.classList.add('player-card--alert');
-        if (currentPlayer === player) {
-          badge.textContent = 'Под ударом';
-        }
-      }
-    });
-  }
-
-  function updateCaptured() {
-    const order = ['commander', 'sentinel', 'strider', 'lancer', 'squire'];
-    ['dawn', 'dusk'].forEach((player) => {
-      const container = capturedEls[player];
-      container.innerHTML = '';
-      const counts = capturedPieces[player].reduce((acc, type) => {
-        acc[type] = (acc[type] || 0) + 1;
-        return acc;
-      }, {});
-      const entries = order.filter((type) => counts[type]);
-      if (entries.length === 0) {
-        const empty = document.createElement('span');
-        empty.className = 'captured__empty';
-        empty.textContent = 'Пока без трофеев';
-        container.appendChild(empty);
-        return;
-      }
-      entries.forEach((type) => {
-        const span = document.createElement('span');
-        const glyph = document.createElement('span');
-        glyph.setAttribute('aria-hidden', 'true');
-        glyph.textContent = PIECES[type].glyph[otherPlayer(player)];
-        const count = document.createElement('strong');
-        count.textContent = `${counts[type]}×`;
-        const label = document.createTextNode(` ${PIECES[type].name}`);
-        span.append(glyph, count, label);
-        container.appendChild(span);
-      });
-    });
-  }
-
-  function renderMoveLog() {
-    moveLogEl.innerHTML = '';
-    for (let i = 0; i < moveHistory.length; i += 2) {
-      const entry = document.createElement('li');
-      entry.className = 'move-log__entry';
-      const turnNumber = Math.floor(i / 2) + 1;
-      const turnLabel = document.createElement('span');
-      turnLabel.className = 'move-log__turn';
-      turnLabel.textContent = `${turnNumber}`;
-      const row = document.createElement('div');
-      row.className = 'move-log__row';
-      row.appendChild(createMoveLogCell(moveHistory[i]));
-      row.appendChild(createMoveLogCell(moveHistory[i + 1]));
-      entry.append(turnLabel, row);
-      moveLogEl.appendChild(entry);
     }
   }
+  for (const option of currentOptions) {
+    const cell = cells[option.y][option.x];
+    cell.classList.add("cell--option");
+    if (option.capture || option.swap) {
+      cell.classList.add("cell--capture");
+    }
+  }
+}
 
-  function createMoveLogCell(entry) {
-    const cell = document.createElement('div');
-    cell.className = 'move-log__cell';
-    if (!entry) {
-      cell.classList.add('move-log__cell--empty');
-      cell.textContent = '…';
-      return cell;
-    }
-    const playerLabel = document.createElement('span');
-    playerLabel.className = 'move-log__player';
-    playerLabel.textContent = PLAYERS[entry.player].name;
-    const notation = document.createElement('span');
-    notation.className = 'move-log__notation';
-    notation.textContent = `${PIECES[entry.pieceType].glyph[entry.player]} ${entry.notation}`;
-    const detail = document.createElement('p');
-    detail.className = 'move-log__detail';
-    const flags = [];
-    if (entry.capture) {
-      flags.push('взято');
-    }
-    if (entry.promotion) {
-      flags.push(`повышение → ${PIECES[entry.promotion].name}`);
-    }
-    if (entry.checkmate) {
-      flags.push('мат');
-    } else if (entry.check) {
-      flags.push('шах');
-    }
-    if (entry.stalemate) {
-      flags.push('пат');
-    }
-    detail.textContent = flags.length ? flags.join(' · ') : 'манёвр';
-    cell.append(playerLabel, notation, detail);
-    return cell;
+function handleCellInteraction(x, y) {
+  if (elements.endgame.hidden === false) return;
+
+  const piece = board[y][x];
+  const current = selectedCell ? board[selectedCell.y][selectedCell.x] : null;
+  const option = currentOptions.find((opt) => opt.x === x && opt.y === y);
+
+  if (option && current) {
+    executeMove(option, current, selectedCell);
+    return;
   }
 
-  function updatePieceFocus(piece, row, col) {
-    focusEls.traits.innerHTML = '';
-    focusEls.stats.innerHTML = '';
-    if (!piece) {
-      focusEls.card.classList.add('focus-card--empty');
-      focusEls.glyph.textContent = '☆';
-      focusEls.name.textContent = 'Выберите фигуру, чтобы узнать её сильные стороны';
-      focusEls.role.textContent = '';
-      focusEls.summary.textContent = '';
-      focusEls.movement.textContent = '';
-      focusEls.position.textContent = '';
-      focusEls.status.textContent = '';
-      focusEls.promotion.textContent = '';
-      const placeholder = document.createElement('li');
-      placeholder.className = 'tag-list__placeholder';
-      placeholder.textContent = 'Тактическое досье появится здесь';
-      focusEls.traits.appendChild(placeholder);
+  if (piece && piece.player === currentPlayer) {
+    selectCell(x, y);
+  } else if (piece && piece.player !== currentPlayer) {
+    setStatus(`${PLAYERS[currentPlayer].name}: нельзя управлять фигурой соперника.`);
+  } else {
+    clearSelection();
+  }
+}
+
+function selectCell(x, y) {
+  selectedCell = { x, y };
+  const piece = board[y][x];
+  const def = PIECE_DEFS[piece.type];
+  currentOptions = def.movement(board, x, y, piece);
+  renderBoard();
+  updateRotateControls(def.canRotate);
+  const movesText = currentOptions.length
+    ? `Доступно ходов: ${currentOptions.map((opt) => toNotation(opt.x, opt.y)).join(", ")}`
+    : def.canRotate
+      ? "Можно только повернуть выбранную фигуру."
+      : "Для этой фигуры доступных действий нет.";
+  elements.hint.textContent = `${def.name}: ${movesText}`;
+  setStatus(`${PLAYERS[currentPlayer].name}: выбрана фигура ${def.name} на ${toNotation(x, y)}.`);
+}
+
+function clearSelection() {
+  selectedCell = null;
+  currentOptions = [];
+  renderBoard();
+  updateRotateControls(false);
+  elements.hint.textContent = "Выберите свою фигуру, чтобы увидеть доступные ходы.";
+}
+
+function updateRotateControls(enabled) {
+  const piece = selectedCell ? board[selectedCell.y][selectedCell.x] : null;
+  const canRotate = Boolean(enabled && piece && piece.player === currentPlayer);
+  elements.rotateLeft.disabled = !canRotate;
+  elements.rotateRight.disabled = !canRotate;
+}
+
+function executeMove(option, piece, from) {
+  const fromNotation = toNotation(from.x, from.y);
+  const targetPiece = board[option.y][option.x];
+
+  if (option.swap && targetPiece) {
+    board[from.y][from.x] = targetPiece;
+    board[option.y][option.x] = piece;
+    setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} меняется местами с ${PIECE_DEFS[targetPiece.type].name} на ${toNotation(option.x, option.y)}.`);
+    logAction(`${PIECE_DEFS[piece.type].name} ${fromNotation} ↔ ${toNotation(option.x, option.y)}`);
+  } else {
+    board[from.y][from.x] = null;
+    board[option.y][option.x] = piece;
+    let actionText = `${PIECE_DEFS[piece.type].name} ${fromNotation} → ${toNotation(option.x, option.y)}`;
+    if (targetPiece) {
+      actionText += ` (захват ${PIECE_DEFS[targetPiece.type].name})`;
+      setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} захватывает ${PIECE_DEFS[targetPiece.type].name}.`);
+    } else {
+      setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} перемещён на ${toNotation(option.x, option.y)}.`);
+    }
+    logAction(actionText);
+  }
+
+  endTurn();
+}
+
+function rotateSelected(delta) {
+  if (!selectedCell) return;
+  const piece = board[selectedCell.y][selectedCell.x];
+  const def = PIECE_DEFS[piece.type];
+  if (!def.canRotate || piece.player !== currentPlayer) return;
+
+  piece.orientation = mod4(piece.orientation + delta);
+  renderBoard();
+  const dirSymbol = delta > 0 ? "↻" : "↺";
+  setStatus(`${PLAYERS[currentPlayer].name}: ${def.name} на ${toNotation(selectedCell.x, selectedCell.y)} повёрнут ${delta > 0 ? "по" : "против"} часовой стрелки.`);
+  logAction(`${def.name} ${toNotation(selectedCell.x, selectedCell.y)} ${dirSymbol}`);
+  endTurn();
+}
+
+function endTurn() {
+  clearSelection();
+  const laserResult = fireLaser(currentPlayer);
+  renderBoard();
+  highlightLaserPath(laserResult.path);
+  if (laserResult.hit) {
+    const hitPiece = laserResult.hit.piece;
+    const owner = PLAYERS[hitPiece.player].name;
+    const pieceName = PIECE_DEFS[hitPiece.type].name;
+    const cell = toNotation(laserResult.hit.x, laserResult.hit.y);
+    logAction(`Лазер поражает ${pieceName} (${owner}) на ${cell}`);
+    setStatus(`${laserResult.firer} испепеляет ${pieceName} (${owner}) на ${cell}.`);
+    if (hitPiece.type === "volhv") {
+      finishGame(currentPlayer);
       return;
     }
+  } else if (laserResult.blocked) {
+    const blockPiece = laserResult.blocked.piece;
+    const owner = PLAYERS[blockPiece.player].name;
+    const cell = toNotation(laserResult.blocked.x, laserResult.blocked.y);
+    logAction(`Луч останавливается о ${PIECE_DEFS[blockPiece.type].name} (${owner}) на ${cell}`);
+    setStatus(`${laserResult.firer} не проходит через ${PIECE_DEFS[blockPiece.type].name} на ${cell}.`);
+  }
+  currentPlayer = currentPlayer === "light" ? "shadow" : "light";
+  turnCounter += 1;
+  updateTurnIndicator();
+  if (!laserResult.hit) {
+    setStatus(`${PLAYERS[currentPlayer].name} готовит ход.`);
+  }
+}
 
-    const def = PIECES[piece.type];
-    focusEls.card.classList.remove('focus-card--empty');
-    focusEls.glyph.textContent = def.glyph[piece.owner];
-    focusEls.name.textContent = `${def.name} — ${PLAYERS[piece.owner].name}`;
-    focusEls.role.textContent = def.role;
-    focusEls.summary.textContent = def.description;
-    focusEls.movement.textContent = def.movement;
-    focusEls.position.textContent = `Позиция: ${toNotation(row, col)}`;
-    focusEls.status.textContent = piece.moved ? 'Уже участвовал в манёврах.' : 'Пока не двигался.';
-    if (piece.promotedFrom && piece.promotedFrom !== piece.type) {
-      focusEls.promotion.textContent = `Повышен из ${PIECES[piece.promotedFrom].name}.`;
+function finishGame(winner) {
+  const loser = winner === "light" ? "shadow" : "light";
+  elements.endgame.hidden = false;
+  elements.endgameTitle.textContent = `${PLAYERS[winner].name} побеждает!`;
+  elements.endgameSubtitle.textContent = `Волхв ${PLAYERS[loser].name} уничтожен лучом.`;
+  setStatus(`${PLAYERS[winner].name} добились победы.`);
+  updateRotateControls(false);
+}
+
+function fireLaser(player) {
+  const emitterPos = findEmitter(player);
+  if (!emitterPos) return { path: [], firer: PLAYERS[player].laserName };
+
+  let { x, y } = emitterPos;
+  let direction = board[y][x].orientation % 4;
+  const path = [];
+
+  while (true) {
+    x += DIRECTIONS[direction].dx;
+    y += DIRECTIONS[direction].dy;
+    if (!inBounds(x, y)) {
+      break;
+    }
+    path.push({ x, y });
+    const target = board[y][x];
+    if (!target) {
+      continue;
+    }
+    const interaction = resolveLaserInteraction(target, direction);
+    if (interaction.destroy) {
+      board[y][x] = null;
+    }
+    if (interaction.stop) {
+      const result = {
+        path,
+        hit: interaction.destroy ? { piece: target, x, y } : null,
+        firer: PLAYERS[player].laserName
+      };
+      if (!interaction.destroy) {
+        result.blocked = { piece: target, x, y };
+      }
+      return result;
+    }
+    direction = interaction.nextDirection;
+  }
+
+  return {
+    path,
+    hit: null,
+    firer: PLAYERS[player].laserName
+  };
+}
+
+function resolveLaserInteraction(piece, incomingDirection) {
+  const face = mod4(incomingDirection + 2);
+  switch (piece.type) {
+    case "pyramid":
+      return pyramidInteraction(piece.orientation, face);
+    case "scarab":
+      return scarabInteraction(piece.orientation, face);
+    case "anubis":
+      return anubisInteraction(piece.orientation, face);
+    case "laser":
+      return { destroy: true, stop: true };
+    case "obelisk":
+    case "volhv":
+      return { destroy: true, stop: true };
+    default:
+      return { destroy: true, stop: true };
+  }
+}
+
+function pyramidInteraction(orientation, face) {
+  const baseMap = {
+    0: 1,
+    1: 0
+  };
+  const rotatedMap = rotateFaceMap(baseMap, orientation);
+  if (face in rotatedMap) {
+    return { destroy: false, stop: false, nextDirection: rotatedMap[face] };
+  }
+  return { destroy: true, stop: true };
+}
+
+function scarabInteraction(orientation, face) {
+  const baseMap = {
+    0: 1,
+    1: 0,
+    2: 3,
+    3: 2
+  };
+  const rotatedMap = rotateFaceMap(baseMap, orientation);
+  if (face in rotatedMap) {
+    return { destroy: false, stop: false, nextDirection: rotatedMap[face] };
+  }
+  return { destroy: true, stop: true };
+}
+
+function anubisInteraction(orientation, face) {
+  const shieldFace = orientation % 4;
+  if (face === shieldFace) {
+    return { destroy: false, stop: true };
+  }
+  return { destroy: true, stop: true };
+}
+
+function rotateFaceMap(map, orientation) {
+  const rotated = {};
+  for (const [face, outDir] of Object.entries(map)) {
+    const newFace = mod4(Number(face) + orientation);
+    const newOut = mod4(outDir + orientation);
+    rotated[newFace] = newOut;
+  }
+  return rotated;
+}
+
+function findEmitter(player) {
+  for (let y = 0; y < BOARD_HEIGHT; y++) {
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      const piece = board[y][x];
+      if (piece && piece.player === player && piece.type === "laser") {
+        return { x, y };
+      }
+    }
+  }
+  return null;
+}
+
+function highlightLaserPath(path) {
+  clearLaserPath();
+  lastLaserPath = path;
+  for (const step of path) {
+    const cell = cells[step.y][step.x];
+    cell.classList.add("cell--laser-trace");
+  }
+}
+
+function clearLaserPath() {
+  for (const step of lastLaserPath) {
+    const cell = cells[step.y][step.x];
+    if (cell) cell.classList.remove("cell--laser-trace");
+  }
+  lastLaserPath = [];
+}
+
+function orthogonalMoves(boardState, x, y, piece) {
+  const moves = [];
+  for (const dir of DIRECTIONS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
+    if (!inBounds(nx, ny)) continue;
+    const target = boardState[ny][nx];
+    if (!target) {
+      moves.push({ x: nx, y: ny });
+    } else if (target.player !== piece.player) {
+      moves.push({ x: nx, y: ny, capture: true });
+    }
+  }
+  return moves;
+}
+
+function diagonalMoves(boardState, x, y, piece) {
+  const moves = [];
+  for (const dir of DIAGONALS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
+    if (!inBounds(nx, ny)) continue;
+    const target = boardState[ny][nx];
+    if (!target) {
+      moves.push({ x: nx, y: ny });
+    } else if (target.player !== piece.player) {
+      moves.push({ x: nx, y: ny, capture: true });
+    }
+  }
+  return moves;
+}
+
+function scarabMoves(boardState, x, y, piece) {
+  const moves = [];
+  for (const dir of DIRECTIONS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
+    if (!inBounds(nx, ny)) continue;
+    const target = boardState[ny][nx];
+    if (!target) {
+      moves.push({ x: nx, y: ny });
     } else {
-      focusEls.promotion.textContent = '';
+      moves.push({ x: nx, y: ny, swap: true });
     }
-
-    def.traits.forEach((trait) => {
-      const li = document.createElement('li');
-      li.textContent = trait;
-      focusEls.traits.appendChild(li);
-    });
-
-    Object.entries(def.stats).forEach(([key, value]) => {
-      const dt = document.createElement('dt');
-      dt.textContent = key;
-      const dd = document.createElement('dd');
-      dd.textContent = value;
-      focusEls.stats.append(dt, dd);
-    });
   }
+  return moves;
+}
 
-  function populateCodex() {
-    codexEl.innerHTML = '';
-    Object.entries(PIECES).forEach(([type, def]) => {
-      const card = document.createElement('article');
-      card.className = `codex-card codex-card--${type}`;
-      const header = document.createElement('div');
-      header.className = 'codex-card__header';
-      const glyph = document.createElement('span');
-      glyph.className = 'codex-card__glyph';
-      glyph.textContent = def.glyph.dawn;
-      const titleWrap = document.createElement('div');
-      const title = document.createElement('h3');
-      title.className = 'codex-card__title';
-      title.textContent = def.name;
-      const role = document.createElement('p');
-      role.className = 'codex-card__role';
-      role.textContent = def.role;
-      titleWrap.append(title, role);
-      header.append(glyph, titleWrap);
-      const desc = document.createElement('p');
-      desc.className = 'codex-card__text';
-      desc.textContent = def.description;
-      const move = document.createElement('p');
-      move.className = 'codex-card__text';
-      move.textContent = def.movement;
-      const traits = document.createElement('ul');
-      traits.className = 'tag-list';
-      def.traits.forEach((trait) => {
-        const li = document.createElement('li');
-        li.textContent = trait;
-        traits.appendChild(li);
-      });
-      const stats = document.createElement('dl');
-      stats.className = 'stat-list';
-      Object.entries(def.stats).forEach(([key, value]) => {
-        const dt = document.createElement('dt');
-        dt.textContent = key;
-        const dd = document.createElement('dd');
-        dd.textContent = value;
-        stats.append(dt, dd);
-      });
-      card.append(header, desc, move, traits, stats);
-      codexEl.appendChild(card);
-    });
-  }
+function inBounds(x, y) {
+  return x >= 0 && x < BOARD_WIDTH && y >= 0 && y < BOARD_HEIGHT;
+}
 
-  function toNotation(row, col) {
-    const letter = COLUMN_LETTERS[col] || '?';
-    const number = ROW_NUMBERS[row] || row + 1;
-    return `${letter}${number}`;
-  }
+function mod4(value) {
+  return (value % 4 + 4) % 4;
+}
 
-  function otherPlayer(player) {
-    return player === 'dawn' ? 'dusk' : 'dawn';
-  }
+function toNotation(x, y) {
+  return `${FILES[x]}${BOARD_HEIGHT - y}`;
+}
 
-  function createInitialBoard() {
-    const backline = ['sentinel', 'lancer', 'commander', 'strider', 'lancer', 'sentinel'];
-    const boardState = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
-    for (let col = 0; col < BOARD_SIZE; col += 1) {
-      boardState[0][col] = createPiece(backline[col], 'dusk');
-      boardState[1][col] = createPiece('squire', 'dusk');
-      boardState[BOARD_SIZE - 2][col] = createPiece('squire', 'dawn');
-      boardState[BOARD_SIZE - 1][col] = createPiece(backline[col], 'dawn');
+function updateTurnIndicator() {
+  elements.turn.textContent = `${turnCounter}. ${PLAYERS[currentPlayer].name}`;
+}
+
+function setStatus(message) {
+  elements.status.textContent = message;
+}
+
+function logAction(text) {
+  const item = document.createElement("li");
+  item.textContent = `${turnCounter}. ${PLAYERS[currentPlayer].name}: ${text}`;
+  elements.log.appendChild(item);
+  elements.log.scrollTop = elements.log.scrollHeight;
+}
+
+function clearLog() {
+  elements.log.innerHTML = "";
+}
+
+function initialiseTheme() {
+  let theme = null;
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      theme = stored;
     }
-    return boardState;
+  } catch (err) {
+    theme = null;
   }
-
-  function createPiece(type, owner) {
-    return { type, owner, moved: false };
+  if (!theme && window.matchMedia) {
+    theme = window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
   }
+  setTheme(theme || "dark");
+}
 
-  function cloneBoard(boardState) {
-    return boardState.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
+function toggleTheme() {
+  const nextTheme = currentTheme === "light" ? "dark" : "light";
+  setTheme(nextTheme);
+}
+
+function setTheme(theme) {
+  currentTheme = theme === "light" ? "light" : "dark";
+  document.body.classList.toggle("theme-light", currentTheme === "light");
+  document.body.classList.toggle("theme-dark", currentTheme === "dark");
+  document.documentElement.style.colorScheme = currentTheme === "light" ? "light" : "dark";
+  if (elements.themeToggle) {
+    const buttonLabel = currentTheme === "light" ? "Тёмная тема" : "Светлая тема";
+    elements.themeToggle.textContent = buttonLabel;
+    elements.themeToggle.setAttribute("aria-pressed", currentTheme === "light" ? "true" : "false");
+    elements.themeToggle.setAttribute("aria-label", `Переключить тему. Текущая тема: ${currentTheme === "light" ? "светлая" : "тёмная"}.`);
   }
-
-  function applyMoveOnBoard(boardState, fromRow, fromCol, toRow, toCol, options = {}) {
-    const clone = cloneBoard(boardState);
-    const piece = clone[fromRow][fromCol];
-    clone[fromRow][fromCol] = null;
-    if (!piece) {
-      return clone;
-    }
-    const movedPiece = { ...piece, moved: true };
-    if (options.promotion) {
-      movedPiece.promotedFrom = movedPiece.promotedFrom || movedPiece.type;
-      movedPiece.type = options.promotion;
-    }
-    clone[toRow][toCol] = movedPiece;
-    return clone;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+  } catch (err) {
+    // игнорируем, если локальное хранилище недоступно
   }
-
-  function getLegalMoves(row, col) {
-    return getLegalMovesForBoard(board, row, col, currentPlayer);
-  }
-
-  function getLegalMovesForBoard(boardState, row, col, player) {
-    const piece = boardState[row][col];
-    if (!piece || piece.owner !== player) {
-      return [];
-    }
-    const pseudoMoves = generatePseudoMoves(boardState, row, col, piece, 'move');
-    const legal = [];
-    for (const move of pseudoMoves) {
-      const target = boardState[move.row][move.col];
-      if (target && target.owner === player) {
-        continue;
-      }
-      const promotionType = piece.type === 'squire' && move.row === promotionRowFor(player) ? 'strider' : null;
-      const boardAfter = applyMoveOnBoard(boardState, row, col, move.row, move.col, { promotion: promotionType });
-      const commander = findCommander(boardAfter, player);
-      if (!commander) {
-        continue;
-      }
-      if (isSquareUnderAttack(boardAfter, commander.row, commander.col, otherPlayer(player))) {
-        continue;
-      }
-      legal.push({
-        row: move.row,
-        col: move.col,
-        capture: Boolean(target),
-        promotion: promotionType
-      });
-    }
-    return legal;
-  }
-
-  function hasLegalMoves(boardState, player) {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const piece = boardState[row][col];
-        if (piece && piece.owner === player) {
-          const moves = getLegalMovesForBoard(boardState, row, col, player);
-          if (moves.length > 0) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
-
-  function promotionRowFor(player) {
-    return player === 'dawn' ? 0 : BOARD_SIZE - 1;
-  }
-
-  function isCommanderInCheck(boardState, player) {
-    const commander = findCommander(boardState, player);
-    if (!commander) {
-      return false;
-    }
-    return isSquareUnderAttack(boardState, commander.row, commander.col, otherPlayer(player));
-  }
-
-  function findCommander(boardState, player) {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const piece = boardState[row][col];
-        if (piece && piece.owner === player && piece.type === 'commander') {
-          return { row, col };
-        }
-      }
-    }
-    return null;
-  }
-
-  function isSquareUnderAttack(boardState, targetRow, targetCol, attacker) {
-    for (let row = 0; row < BOARD_SIZE; row += 1) {
-      for (let col = 0; col < BOARD_SIZE; col += 1) {
-        const piece = boardState[row][col];
-        if (!piece || piece.owner !== attacker) {
-          continue;
-        }
-        const threats = generatePseudoMoves(boardState, row, col, piece, 'threat');
-        if (threats.some((move) => move.row === targetRow && move.col === targetCol)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  function generatePseudoMoves(boardState, row, col, piece, purpose) {
-    const moves = [];
-    const owner = piece.owner;
-    const isThreat = purpose === 'threat';
-
-    const pushSliding = (directions) => {
-      directions.forEach(([dr, dc]) => {
-        let r = row + dr;
-        let c = col + dc;
-        while (isInside(r, c)) {
-          const occupant = boardState[r][c];
-          if (!occupant) {
-            moves.push({ row: r, col: c });
-          } else {
-            if (occupant.owner !== owner) {
-              moves.push({ row: r, col: c });
-            }
-            break;
-          }
-          r += dr;
-          c += dc;
-        }
-      });
-    };
-
-    switch (piece.type) {
-      case 'commander': {
-        for (let dr = -1; dr <= 1; dr += 1) {
-          for (let dc = -1; dc <= 1; dc += 1) {
-            if (dr === 0 && dc === 0) continue;
-            const r = row + dr;
-            const c = col + dc;
-            if (!isInside(r, c)) continue;
-            const occupant = boardState[r][c];
-            if (occupant && occupant.owner === owner) continue;
-            moves.push({ row: r, col: c });
-          }
-        }
-        break;
-      }
-      case 'sentinel': {
-        pushSliding([
-          [1, 0],
-          [-1, 0],
-          [0, 1],
-          [0, -1]
-        ]);
-        break;
-      }
-      case 'strider': {
-        pushSliding([
-          [1, 1],
-          [1, -1],
-          [-1, 1],
-          [-1, -1]
-        ]);
-        break;
-      }
-      case 'lancer': {
-        const jumps = [
-          [2, 1], [2, -1],
-          [-2, 1], [-2, -1],
-          [1, 2], [1, -2],
-          [-1, 2], [-1, -2]
-        ];
-        jumps.forEach(([dr, dc]) => {
-          const r = row + dr;
-          const c = col + dc;
-          if (!isInside(r, c)) return;
-          const occupant = boardState[r][c];
-          if (occupant && occupant.owner === owner) return;
-          moves.push({ row: r, col: c });
-        });
-        break;
-      }
-      case 'squire': {
-        const dir = directionByPlayer[owner];
-        const forwardRow = row + dir;
-        if (purpose === 'move') {
-          if (isInside(forwardRow, col) && !boardState[forwardRow][col]) {
-            moves.push({ row: forwardRow, col });
-            const doubleRow = forwardRow + dir;
-            if (!piece.moved && isInside(doubleRow, col) && !boardState[doubleRow][col]) {
-              moves.push({ row: doubleRow, col });
-            }
-          }
-          [-1, 1].forEach((dc) => {
-            const r = row + dir;
-            const c = col + dc;
-            if (!isInside(r, c)) return;
-            const occupant = boardState[r][c];
-            if (occupant && occupant.owner !== owner) {
-              moves.push({ row: r, col: c });
-            }
-          });
-        } else {
-          [-1, 1].forEach((dc) => {
-            const r = row + dir;
-            const c = col + dc;
-            if (isInside(r, c)) {
-              moves.push({ row: r, col: c });
-            }
-          });
-        }
-        break;
-      }
-      default:
-        break;
-    }
-
-    if (isThreat && piece.type !== 'squire') {
-      // For threats we should not include squares beyond allied pieces; already handled.
-      return moves;
-    }
-
-    return moves;
-  }
-
-  function isInside(row, col) {
-    return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
-  }
-
-  start();
-})();
+}

--- a/style.css
+++ b/style.css
@@ -245,10 +245,10 @@ body.theme-light .button--primary {
 
 .board {
   display: grid;
-  grid-template-columns: repeat(8, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--board-columns, 8), minmax(0, 1fr));
   grid-auto-rows: 1fr;
-  width: min(820px, 96vw);
-  aspect-ratio: 1 / 1;
+  width: min(900px, 96vw);
+  aspect-ratio: var(--board-columns, 8) / var(--board-rows, 8);
   border-radius: 18px;
   overflow: hidden;
   border: 1px solid var(--panel-border-color);
@@ -303,10 +303,10 @@ body.theme-light .button--primary {
   background: rgba(107, 154, 255, 0.18);
 }
 
-.cell--capture::after {
+.cell--swap::after {
   border-style: solid;
-  background: rgba(255, 94, 94, 0.25);
-  border-color: var(--laser);
+  background: rgba(107, 154, 255, 0.24);
+  border-color: rgba(107, 154, 255, 0.8);
 }
 
 .piece {

--- a/style.css
+++ b/style.css
@@ -6,6 +6,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -296,7 +300,7 @@ body.theme-light .button--primary {
 .board {
   display: grid;
   grid-template-columns: repeat(8, minmax(0, 1fr));
-  width: min(520px, 92vw);
+  width: min(650px, 96vw);
   aspect-ratio: 1 / 1;
   border-radius: 18px;
   overflow: hidden;
@@ -326,7 +330,7 @@ body.theme-light .button--primary {
   background: var(--cell-dark);
   display: grid;
   place-items: center;
-  font-size: clamp(1.5rem, 2.4vw, 2.4rem);
+  font-size: clamp(1.8rem, 3vw, 3rem);
   line-height: 1;
   border: 1px solid var(--cell-border);
   box-shadow: inset 0 0 0 1px var(--cell-inner-glow);
@@ -451,12 +455,65 @@ body.theme-light .piece {
   gap: 1rem;
   place-items: center;
   text-align: center;
+  z-index: 4;
 }
 
 .laser-overlay {
   pointer-events: none;
   position: absolute;
   inset: 0;
+  z-index: 3;
+}
+
+.laser-overlay__beam {
+  position: absolute;
+  height: 1.6%;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.2), var(--laser));
+  box-shadow: 0 0 18px var(--laser), 0 0 36px rgba(255, 94, 94, 0.55);
+  border-radius: 999px;
+  transform-origin: 0 50%;
+  opacity: 0;
+  animation: laser-trace 0.45s ease forwards;
+}
+
+.laser-overlay__impact {
+  position: absolute;
+  width: 6%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, var(--laser) 45%, rgba(255, 94, 94, 0) 70%);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 22px rgba(255, 94, 94, 0.6);
+  animation: laser-impact 0.5s ease forwards;
+}
+
+@keyframes laser-trace {
+  0% {
+    opacity: 0;
+    filter: blur(4px);
+  }
+  40% {
+    opacity: 0.9;
+    filter: blur(0.8px);
+  }
+  100% {
+    opacity: 0.75;
+    filter: blur(1.2px);
+  }
+}
+
+@keyframes laser-impact {
+  0% {
+    transform: translate(-50%, -50%) scale(0.3);
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.6;
+  }
 }
 
 @media (max-width: 960px) {
@@ -495,7 +552,7 @@ body.theme-light .piece {
 
   .board {
     width: 100%;
-    max-width: 520px;
+    max-width: 650px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -122,7 +122,7 @@ body > * {
   width: min(1100px, 100%);
   display: grid;
   gap: 1rem;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: minmax(0, 1fr) 280px;
   align-items: start;
 }
 
@@ -130,46 +130,6 @@ body > * {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.sidebar__hero {
-  background: linear-gradient(135deg, var(--hero-gradient-start), var(--hero-gradient-end));
-  border-radius: 18px;
-  padding: 1.5rem;
-  backdrop-filter: blur(6px);
-  box-shadow: var(--panel-elevation);
-  border: 1px solid var(--panel-border-color);
-  position: relative;
-  overflow: hidden;
-}
-
-.sidebar__hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.18), transparent 55%);
-  opacity: 0.35;
-  pointer-events: none;
-}
-
-.sidebar__overtitle {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
-  margin: 0 0 0.5rem;
-  color: var(--accent-light);
-}
-
-.sidebar__hero h1 {
-  margin: 0;
-  font-size: 2rem;
-}
-
-.sidebar__intro {
-  margin: 0.5rem 0 1rem;
-  color: var(--muted);
-  line-height: 1.5;
 }
 
 .panel {
@@ -191,12 +151,6 @@ body > * {
 .panel__turn {
   margin: 0;
   font-size: 1.15rem;
-}
-
-.panel__hint {
-  margin: 0.75rem 0 0;
-  color: var(--muted);
-  font-size: 0.9rem;
 }
 
 .legend {
@@ -623,16 +577,11 @@ body.theme-light .board-action {
     gap: 0.75rem;
   }
 
-  .sidebar__hero {
-    flex: 1 1 100%;
-  }
-
   .panel {
     flex: 1 1 min(280px, 100%);
   }
 
-    .panel--legend,
-    .sidebar__intro {
+  .panel--legend {
     display: none;
   }
 
@@ -647,12 +596,7 @@ body.theme-light .board-action {
     padding: 0.5rem;
   }
 
-  .sidebar__hero h1 {
-    font-size: 1.6rem;
-  }
-
-  .panel,
-  .sidebar__hero {
+  .panel {
     padding: 1rem;
   }
 

--- a/style.css
+++ b/style.css
@@ -221,14 +221,6 @@ body > * {
   color: var(--accent-light);
 }
 
-.hero__actions {
-  display: flex;
-  gap: 0.65rem;
-  flex-wrap: wrap;
-  margin-top: 1.25rem;
-  align-items: center;
-}
-
 .button {
   appearance: none;
   border: none;
@@ -300,7 +292,8 @@ body.theme-light .button--primary {
 .board {
   display: grid;
   grid-template-columns: repeat(8, minmax(0, 1fr));
-  width: min(650px, 96vw);
+  grid-auto-rows: 1fr;
+  width: min(820px, 96vw);
   aspect-ratio: 1 / 1;
   border-radius: 18px;
   overflow: hidden;
@@ -360,10 +353,6 @@ body.theme-light .button--primary {
   border-style: solid;
   background: rgba(255, 94, 94, 0.25);
   border-color: var(--laser);
-}
-
-.cell--laser-trace {
-  box-shadow: inset 0 0 0 3px var(--laser-trace-glow);
 }
 
 .piece {
@@ -428,22 +417,6 @@ body.theme-light .piece {
   color: var(--muted);
 }
 
-.log {
-  margin: 0;
-  padding-left: 1.5rem;
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  max-height: 240px;
-  overflow: auto;
-}
-
-.actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
 .endgame {
   position: absolute;
   inset: 10%;
@@ -463,6 +436,120 @@ body.theme-light .piece {
   position: absolute;
   inset: 0;
   z-index: 3;
+}
+
+.board-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.toolbar-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.toolbar-button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.toolbar-button--primary {
+  background: linear-gradient(135deg, var(--accent-light), rgba(255, 138, 76, 0.95));
+  color: #221400;
+  box-shadow: none;
+}
+
+.toolbar-button--icon {
+  width: 2.5rem;
+  padding: 0;
+  font-size: 1.2rem;
+}
+
+body.theme-light .toolbar-button {
+  background: rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+body.theme-light .toolbar-button:hover {
+  background: rgba(15, 23, 42, 0.14);
+}
+
+body.theme-light .toolbar-button--primary {
+  color: #432006;
+}
+
+.board-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
+.board-action {
+  appearance: none;
+  border: none;
+  border-radius: 16px;
+  width: 3.5rem;
+  height: 3.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.board-action:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.board-action:not(:disabled):hover {
+  transform: translateY(-2px);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.08));
+}
+
+body.theme-light .board-action {
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.12), rgba(15, 23, 42, 0.04));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.panel--piece {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.piece-panel__name {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.piece-panel__details {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 
 .laser-overlay__beam {
@@ -544,9 +631,8 @@ body.theme-light .piece {
     flex: 1 1 min(280px, 100%);
   }
 
-  .panel--legend,
-  .panel--log,
-  .sidebar__intro {
+    .panel--legend,
+    .sidebar__intro {
     display: none;
   }
 

--- a/style.css
+++ b/style.css
@@ -1,733 +1,519 @@
 :root {
-  color-scheme: dark;
-  --bg: radial-gradient(circle at 20% 20%, #182347 0%, #0a0f1f 55%, #050812 100%);
-  --panel-bg: rgba(12, 22, 45, 0.79);
-  --panel-border: rgba(120, 167, 255, 0.2);
-  --text-primary: #dde7ff;
-  --text-muted: #94a3c7;
-  --accent-dawn: #f6d47f;
-  --accent-dusk: #7aa5ff;
-  --accent-neutral: rgba(255, 255, 255, 0.08);
-  --cell-light: linear-gradient(145deg, rgba(95, 130, 197, 0.35), rgba(26, 42, 74, 0.7));
-  --cell-dark: linear-gradient(145deg, rgba(18, 30, 56, 0.9), rgba(11, 19, 33, 0.95));
-  --highlight-move: rgba(134, 215, 255, 0.35);
-  --highlight-capture: rgba(255, 126, 158, 0.42);
-  --highlight-selected: rgba(255, 255, 255, 0.65);
-  --highlight-check: rgba(255, 182, 92, 0.55);
-  --focus-shadow: 0 18px 40px rgba(5, 8, 20, 0.55);
-  font-family: "Segoe UI", "Roboto", "Nunito", sans-serif;
+  --font-family: "Montserrat", "Segoe UI", sans-serif;
 }
 
-*, *::before, *::after {
+* {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
-  color: var(--text-primary);
-}
-
-button {
-  font: inherit;
-}
-
-.shell {
-  max-width: 1220px;
-  margin: 0 auto;
-  padding: clamp(16px, 4vw, 40px);
+  font-family: var(--font-family);
+  background: var(--page-gradient, var(--bg));
+  color: var(--text);
   display: flex;
-  flex-direction: column;
-  gap: clamp(20px, 4vw, 32px);
+  justify-content: center;
+  padding: 1rem;
+  transition: background 0.6s ease, color 0.4s ease;
+  position: relative;
+  overflow-x: hidden;
 }
 
-.hero {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: clamp(16px, 4vw, 40px);
-  background: linear-gradient(145deg, rgba(35, 58, 112, 0.38), rgba(9, 15, 28, 0.85));
-  border: 1px solid rgba(140, 180, 255, 0.2);
-  border-radius: 28px;
-  padding: clamp(18px, 4vw, 32px);
-  box-shadow: 0 25px 60px rgba(4, 9, 28, 0.5);
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    radial-gradient(600px circle at 12% 8%, var(--veil-primary), transparent 58%),
+    radial-gradient(520px circle at 88% 90%, var(--veil-secondary), transparent 60%),
+    repeating-conic-gradient(from 45deg, transparent 0 24deg, var(--veil-grid) 24deg 27deg);
+  opacity: var(--background-veil-opacity, 0.35);
+  mix-blend-mode: var(--background-veil-blend, screen);
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+  z-index: 0;
 }
 
-.hero__text {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+body.theme-dark {
+  color-scheme: dark;
+  --bg: #0f1417;
+  --bg-panel: rgba(22, 29, 34, 0.95);
+  --accent-light: #ffd166;
+  --accent-dark: #6b9aff;
+  --text: #f0f6ff;
+  --muted: #95a4b7;
+  --grid-line: rgba(255, 255, 255, 0.08);
+  --laser: #ff5e5e;
+  --page-gradient: radial-gradient(circle at top left, rgba(255, 220, 128, 0.08), transparent 42%),
+                   radial-gradient(circle at bottom right, rgba(120, 180, 255, 0.12), transparent 36%),
+                   var(--bg);
+  --background-veil-opacity: 0.4;
+  --background-veil-blend: screen;
+  --veil-primary: rgba(255, 220, 128, 0.22);
+  --veil-secondary: rgba(120, 180, 255, 0.18);
+  --veil-grid: rgba(255, 255, 255, 0.04);
+  --panel-border-color: rgba(255, 255, 255, 0.05);
+  --button-ghost-border: rgba(255, 255, 255, 0.28);
+  --button-ghost-hover: rgba(255, 255, 255, 0.14);
+  --button-ghost-text: var(--text);
+  --panel-elevation: 0 20px 38px rgba(0, 0, 0, 0.24);
+  --board-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  --hero-gradient-start: rgba(255, 209, 102, 0.35);
+  --hero-gradient-end: rgba(107, 154, 255, 0.2);
+  --cell-dark: rgba(15, 20, 23, 0.95);
+  --cell-light: rgba(36, 43, 48, 0.95);
+  --cell-border: rgba(255, 255, 255, 0.08);
+  --laser-trace-glow: rgba(255, 94, 94, 0.6);
+  --cell-inner-glow: rgba(255, 255, 255, 0.02);
+  --board-overlay-opacity: 0.45;
+  --board-overlay-blend: screen;
+  --board-overlay-primary: rgba(255, 255, 255, 0.12);
+  --board-overlay-secondary: rgba(255, 255, 255, 0.08);
 }
 
-.hero__overtitle {
-  text-transform: uppercase;
-  letter-spacing: 0.3em;
-  font-size: 0.75rem;
-  color: rgba(198, 212, 255, 0.7);
-  margin: 0;
+body.theme-light {
+  color-scheme: light;
+  --bg: #f4f7fb;
+  --bg-panel: rgba(255, 255, 255, 0.88);
+  --accent-light: #d97706;
+  --accent-dark: #1d4ed8;
+  --text: #0f172a;
+  --muted: #4b5563;
+  --grid-line: rgba(15, 23, 42, 0.08);
+  --laser: #d7263d;
+  --page-gradient: radial-gradient(circle at top left, rgba(244, 196, 94, 0.35), transparent 46%),
+                   radial-gradient(circle at bottom right, rgba(96, 165, 250, 0.24), transparent 42%),
+                   var(--bg);
+  --background-veil-opacity: 0.18;
+  --background-veil-blend: multiply;
+  --veil-primary: rgba(250, 204, 21, 0.25);
+  --veil-secondary: rgba(59, 130, 246, 0.18);
+  --veil-grid: rgba(15, 23, 42, 0.05);
+  --panel-border-color: rgba(15, 23, 42, 0.08);
+  --button-ghost-border: rgba(15, 23, 42, 0.3);
+  --button-ghost-hover: rgba(15, 23, 42, 0.08);
+  --button-ghost-text: #1f2937;
+  --panel-elevation: 0 16px 28px rgba(15, 23, 42, 0.12);
+  --board-shadow: 0 22px 32px rgba(15, 23, 42, 0.14);
+  --hero-gradient-start: rgba(255, 237, 213, 0.92);
+  --hero-gradient-end: rgba(191, 219, 254, 0.65);
+  --cell-dark: rgba(216, 226, 247, 0.9);
+  --cell-light: rgba(247, 250, 255, 0.94);
+  --cell-border: rgba(15, 23, 42, 0.12);
+  --laser-trace-glow: rgba(215, 38, 61, 0.55);
+  --cell-inner-glow: rgba(255, 255, 255, 0.6);
+  --board-overlay-opacity: 0.25;
+  --board-overlay-blend: multiply;
+  --board-overlay-primary: rgba(251, 191, 36, 0.28);
+  --board-overlay-secondary: rgba(59, 130, 246, 0.2);
 }
 
-.hero h1 {
-  font-size: clamp(2.2rem, 4vw, 3rem);
-  margin: 0;
-  line-height: 1.1;
+body > * {
+  position: relative;
+  z-index: 1;
 }
 
-.hero__subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  max-width: 38ch;
-  font-size: 1rem;
-  line-height: 1.5;
-}
-
-.hero__button {
-  align-self: stretch;
-  padding: 14px 24px;
-  border-radius: 16px;
-  border: none;
-  color: #02030a;
-  font-weight: 700;
-  background: linear-gradient(135deg, #f6d47f, #ffd27a 30%, #ffb87d 100%);
-  box-shadow: 0 12px 30px rgba(255, 193, 107, 0.35);
-  cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.hero__button:hover,
-.hero__button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 36px rgba(255, 193, 107, 0.4);
-}
-
-.layout {
+.game {
+  width: min(1100px, 100%);
   display: grid;
-  grid-template-columns: minmax(360px, 1.15fr) minmax(260px, 0.85fr);
-  gap: clamp(18px, 4vw, 32px);
+  gap: 1rem;
+  grid-template-columns: 300px 1fr;
   align-items: start;
 }
 
-.board-area {
+.sidebar {
   display: flex;
   flex-direction: column;
-  gap: clamp(18px, 3vw, 28px);
+  gap: 1rem;
 }
 
-.board-frame {
+.sidebar__hero {
+  background: linear-gradient(135deg, var(--hero-gradient-start), var(--hero-gradient-end));
+  border-radius: 18px;
+  padding: 1.5rem;
+  backdrop-filter: blur(6px);
+  box-shadow: var(--panel-elevation);
+  border: 1px solid var(--panel-border-color);
   position: relative;
-  padding: clamp(12px, 3vw, 18px);
-  border-radius: 28px;
-  background: linear-gradient(150deg, rgba(48, 78, 143, 0.45), rgba(13, 21, 38, 0.9));
-  border: 1px solid rgba(142, 186, 255, 0.18);
-  box-shadow: 0 20px 55px rgba(6, 8, 20, 0.6);
+  overflow: hidden;
+}
+
+.sidebar__hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.18), transparent 55%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.sidebar__overtitle {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  margin: 0 0 0.5rem;
+  color: var(--accent-light);
+}
+
+.sidebar__hero h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.sidebar__intro {
+  margin: 0.5rem 0 1rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.panel {
+  background: var(--bg-panel);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px var(--panel-border-color), var(--panel-elevation);
+  backdrop-filter: blur(10px);
+}
+
+.panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.panel__turn {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panel__hint {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.legend {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.legend__glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+  background: rgba(255, 209, 102, 0.15);
+}
+
+.legend__glyph--light {
+  color: var(--accent-light);
+}
+
+.hero__actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  margin-top: 1.25rem;
+  align-items: center;
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent-light), rgba(255, 138, 76, 0.95));
+  color: #221400;
+}
+
+.button--ghost {
+  background: transparent;
+  border: 1px solid var(--button-ghost-border);
+  color: var(--button-ghost-text);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.button--ghost:not(:disabled):hover {
+  background: var(--button-ghost-hover);
+}
+
+body.theme-light .button {
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--text);
+}
+
+body.theme-light .button:not(:disabled):hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+body.theme-light .button--ghost {
+  background: transparent;
+}
+
+body.theme-light .button--primary {
+  color: #432006;
+}
+
+.board-area {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.board-wrapper {
+  position: relative;
 }
 
 .board {
-  --board-size: 6;
   display: grid;
-  grid-template-columns: repeat(var(--board-size), minmax(52px, 1fr));
-  gap: clamp(6px, 1.4vw, 10px);
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  width: min(520px, 92vw);
+  aspect-ratio: 1 / 1;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid var(--panel-border-color);
+  box-shadow: var(--board-shadow);
+  position: relative;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 70%);
+  isolation: isolate;
+}
+
+.board::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(520px circle at 24% 22%, var(--board-overlay-primary), transparent 55%),
+    radial-gradient(460px circle at 78% 74%, var(--board-overlay-secondary), transparent 58%);
+  opacity: var(--board-overlay-opacity);
+  mix-blend-mode: var(--board-overlay-blend);
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+  z-index: 0;
 }
 
 .cell {
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  aspect-ratio: 1 / 1;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  color: inherit;
-  padding: 0;
-  background: var(--cell-light);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.cell--dark {
   background: var(--cell-dark);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  display: grid;
+  place-items: center;
+  font-size: clamp(1.5rem, 2.4vw, 2.4rem);
+  line-height: 1;
+  border: 1px solid var(--cell-border);
+  box-shadow: inset 0 0 0 1px var(--cell-inner-glow);
+  transition: background 0.2s ease, transform 0.2s ease;
+  z-index: 1;
 }
 
-.cell:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(6, 10, 26, 0.4);
+.cell--light {
+  background: var(--cell-light);
 }
 
-.cell:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
-  outline-offset: 2px;
+.cell--selected {
+  outline: 3px solid var(--accent-light);
+  outline-offset: -3px;
 }
 
-.cell::after {
+.cell--option::after {
   content: "";
   position: absolute;
-  inset: 10%;
-  border-radius: 16px;
-  opacity: 0;
-  transform: scale(0.9);
-  transition: opacity 0.15s ease, transform 0.2s ease;
-}
-
-.cell--selected::after {
-  background: var(--highlight-selected);
-  opacity: 0.4;
-  transform: scale(1);
-}
-
-.cell--move::after {
-  background: var(--highlight-move);
-  opacity: 0.65;
-  transform: scale(1);
+  inset: 20%;
+  border-radius: 12px;
+  border: 2px dashed var(--accent-dark);
+  background: rgba(107, 154, 255, 0.18);
 }
 
 .cell--capture::after {
-  background: var(--highlight-capture);
-  opacity: 0.8;
-  transform: scale(1);
+  border-style: solid;
+  background: rgba(255, 94, 94, 0.25);
+  border-color: var(--laser);
 }
 
-.cell--alert::after {
-  background: var(--highlight-check);
-  opacity: 0.9;
-  transform: scale(1);
-  box-shadow: 0 0 18px rgba(255, 182, 92, 0.8);
+.cell--laser-trace {
+  box-shadow: inset 0 0 0 3px var(--laser-trace-glow);
 }
 
 .piece {
-  width: 72%;
-  height: 72%;
-  border-radius: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  backdrop-filter: blur(4px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22), 0 10px 25px rgba(0, 0, 0, 0.45);
-  transition: transform 0.18s ease;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.5);
+  position: relative;
+  isolation: isolate;
 }
 
-.piece--dawn {
-  background: radial-gradient(circle at 30% 30%, rgba(255, 240, 200, 0.92), rgba(246, 212, 127, 0.95));
-  color: #331b05;
+.piece--light {
+  color: var(--accent-light);
 }
 
-.piece--dusk {
-  background: radial-gradient(circle at 30% 30%, rgba(220, 234, 255, 0.92), rgba(122, 165, 255, 0.96));
-  color: #081231;
+.piece--shadow {
+  color: var(--accent-dark);
+}
+
+body.theme-light .piece {
+  text-shadow: 0 0 14px rgba(255, 255, 255, 0.8);
+}
+
+.piece::before {
+  content: "";
+  position: absolute;
+  inset: 18%;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 65%);
+  filter: blur(0.5px);
+  opacity: 0.65;
+  z-index: -1;
+  pointer-events: none;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.piece--light::before {
+  background: linear-gradient(140deg, rgba(255, 209, 102, 0.48), rgba(255, 255, 255, 0.1));
+}
+
+.piece--shadow::before {
+  background: linear-gradient(140deg, rgba(107, 154, 255, 0.45), rgba(255, 255, 255, 0.08));
+}
+
+.cell:hover .piece::before,
+.cell.cell--selected .piece::before {
+  transform: scale(1.05);
+  opacity: 0.82;
 }
 
 .piece__glyph {
-  text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+  display: inline-block;
+  transition: transform 0.2s ease;
 }
 
 .status {
-  display: grid;
-  gap: 6px;
-  padding: 16px 20px;
-  background: linear-gradient(150deg, rgba(18, 28, 52, 0.85), rgba(10, 16, 31, 0.9));
-  border-radius: 18px;
-  border: 1px solid rgba(120, 167, 255, 0.2);
-  box-shadow: var(--focus-shadow);
-}
-
-.status p {
-  margin: 0;
-  font-size: 0.95rem;
-}
-
-.status p:first-child {
-  font-weight: 600;
-}
-
-.panel {
-  background: var(--panel-bg);
-  border-radius: 26px;
-  border: 1px solid var(--panel-border);
-  padding: clamp(16px, 3vw, 24px);
-  display: grid;
-  gap: clamp(14px, 3vw, 20px);
-  box-shadow: var(--focus-shadow);
-}
-
-.panel__title-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.panel__title {
-  margin: 0;
+  min-height: 2.5rem;
+  text-align: center;
   font-size: 1.1rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.panel__subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  line-height: 1.4;
-}
-
-.player-card {
-  position: relative;
-  background: linear-gradient(155deg, rgba(24, 38, 66, 0.9), rgba(9, 14, 24, 0.9));
-  border-radius: 22px;
-  padding: 16px;
-  border: 1px solid rgba(110, 160, 255, 0.18);
-  display: grid;
-  gap: 12px;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.player-card[data-player="dawn"] .player-card__crest {
-  background: radial-gradient(circle, rgba(246, 212, 127, 0.8), rgba(246, 212, 127, 0));
-}
-
-.player-card[data-player="dusk"] .player-card__crest {
-  background: radial-gradient(circle, rgba(122, 165, 255, 0.85), rgba(122, 165, 255, 0));
-}
-
-.player-card__header {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 14px;
-  align-items: center;
-}
-
-.player-card__crest {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
-}
-
-.player-card__tagline {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.82rem;
-}
-
-.player-card__turn {
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.player-card__body {
-  display: grid;
-  gap: 8px;
-}
-
-.player-card__label {
-  margin: 0;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(201, 211, 245, 0.7);
-}
-
-.captured {
-  min-height: 32px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.captured span {
-  padding: 6px 10px;
-  border-radius: 999px;
-  font-size: 0.9rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.captured span strong {
-  font-weight: 600;
-  color: #fff2c2;
-}
-
-.captured span span {
-  font-size: 1.1rem;
-}
-
-.captured__empty {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.player-card--active {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 38px rgba(10, 16, 34, 0.55);
-}
-
-.player-card--active .player-card__turn {
-  background: linear-gradient(135deg, rgba(246, 212, 127, 0.9), rgba(255, 184, 125, 0.9));
-  color: #1f1304;
-  border-color: rgba(255, 255, 255, 0.4);
-}
-
-.player-card--alert {
-  box-shadow: 0 22px 42px rgba(255, 136, 90, 0.35);
-}
-
-.player-card--alert .player-card__turn {
-  background: linear-gradient(135deg, rgba(255, 145, 98, 0.95), rgba(255, 99, 132, 0.85));
-  color: #2b0508;
-}
-
-.focus-card {
-  display: grid;
-  grid-template-columns: 80px 1fr;
-  gap: 16px;
-  align-items: start;
-  background: linear-gradient(155deg, rgba(19, 32, 58, 0.9), rgba(8, 12, 25, 0.95));
-  border-radius: 22px;
-  padding: 18px;
-  border: 1px solid rgba(130, 175, 255, 0.2);
-  position: relative;
-}
-
-.focus-card__glyph {
-  width: 80px;
-  height: 80px;
-  border-radius: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 2.4rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.focus-card__text {
-  display: grid;
-  gap: 8px;
-}
-
-.focus-card__text h3 {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.focus-card__text p {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.focus-card__movement {
-  color: #ffe6a8;
-}
-
-.focus-card__status {
-  color: #9bd0ff;
-}
-
-.focus-card__promotion {
-  color: #ffd4ba;
-}
-
-.focus-card__traits,
-.focus-card__stats {
-  grid-column: 1 / -1;
-}
-
-.focus-card__traits h4,
-.focus-card__stats h4 {
-  margin: 0 0 8px;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(206, 220, 255, 0.7);
-}
-
-.tag-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.tag-list li {
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  font-size: 0.78rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.tag-list__placeholder {
-  opacity: 0.5;
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.stat-list {
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px 12px;
-}
-
-.stat-list dt {
-  font-size: 0.78rem;
-  color: rgba(206, 220, 255, 0.7);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.stat-list dd {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.focus-card--empty {
-  background: linear-gradient(155deg, rgba(22, 33, 57, 0.7), rgba(7, 11, 24, 0.85));
-}
-
-.focus-card--empty .focus-card__glyph {
-  opacity: 0.4;
-}
-
-.codex {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.codex-card {
-  background: linear-gradient(155deg, rgba(27, 42, 74, 0.85), rgba(12, 20, 38, 0.9));
-  border-radius: 20px;
-  padding: 16px;
-  border: 1px solid rgba(128, 170, 255, 0.18);
-  display: grid;
-  gap: 12px;
-}
-
-.codex-card__header {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 12px;
-}
-
-.codex-card__glyph {
-  width: 46px;
-  height: 46px;
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.8rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.codex-card__title {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.codex-card__role {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.codex-card__text {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.rules {
-  margin: 0;
-  padding-left: 18px;
-  display: grid;
-  gap: 8px;
-  color: var(--text-muted);
-  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .log {
-  gap: 18px;
+  margin: 0;
+  padding-left: 1.5rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  max-height: 240px;
+  overflow: auto;
 }
 
-.move-log {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.actions {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  max-height: clamp(220px, 32vh, 320px);
-  overflow-y: auto;
-  scrollbar-width: thin;
-}
-
-.move-log::-webkit-scrollbar {
-  width: 6px;
-}
-
-.move-log::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-}
-
-.move-log__entry {
-  display: grid;
-  grid-template-columns: 36px 1fr;
-  align-items: start;
-  gap: 12px;
-  background: rgba(13, 21, 38, 0.75);
-  border-radius: 16px;
-  padding: 10px 14px;
-  border: 1px solid rgba(120, 167, 255, 0.18);
-}
-
-.move-log__turn {
-  font-weight: 700;
-  font-size: 1rem;
-  color: rgba(255, 255, 255, 0.82);
-}
-
-.move-log__row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(120px, 1fr));
-  gap: 8px;
-}
-
-.move-log__cell {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 8px 10px;
-  display: grid;
-  gap: 4px;
-}
-
-.move-log__cell--empty {
-  opacity: 0.4;
-  text-align: center;
-  padding: 12px;
-}
-
-.move-log__player {
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(203, 216, 255, 0.6);
-}
-
-.move-log__notation {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.move-log__detail {
-  margin: 0;
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .endgame {
   position: absolute;
-  inset: 0;
+  inset: 10%;
+  border-radius: 18px;
+  padding: 2rem;
+  background: rgba(15, 20, 23, 0.95);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
   display: grid;
+  gap: 1rem;
   place-items: center;
   text-align: center;
-  background: rgba(5, 8, 20, 0.92);
-  border-radius: inherit;
-  border: 1px solid rgba(246, 212, 127, 0.3);
-  backdrop-filter: blur(4px);
-  gap: 12px;
 }
 
-.endgame h2 {
-  margin: 0;
-  font-size: 1.8rem;
-}
-
-.endgame p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
-.endgame__button {
-  padding: 12px 24px;
-  border-radius: 14px;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  background: linear-gradient(135deg, #7aa5ff, #a3c2ff);
-  color: #06112b;
-  box-shadow: 0 12px 28px rgba(122, 165, 255, 0.35);
-}
-
-.sr-only {
+.laser-overlay {
+  pointer-events: none;
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+  inset: 0;
 }
 
-@media (max-width: 1050px) {
-  .layout {
+@media (max-width: 960px) {
+  body {
+    padding: 0.75rem;
+  }
+
+  .game {
     grid-template-columns: 1fr;
   }
 
-  .hero {
-    flex-direction: column;
-    align-items: stretch;
+  .board-area {
+    order: 1;
   }
 
-  .hero__button {
-    align-self: flex-start;
+  .sidebar {
+    order: 2;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
-}
 
-@media (max-width: 720px) {
+  .sidebar__hero {
+    flex: 1 1 100%;
+  }
+
+  .panel {
+    flex: 1 1 min(280px, 100%);
+  }
+
+  .panel--legend,
+  .panel--log,
+  .sidebar__intro {
+    display: none;
+  }
+
   .board {
-    grid-template-columns: repeat(var(--board-size), minmax(40px, 1fr));
-  }
-
-  .move-log__row {
-    grid-template-columns: 1fr;
+    width: 100%;
+    max-width: 520px;
   }
 }
 
 @media (max-width: 540px) {
-  .focus-card {
-    grid-template-columns: 1fr;
-    text-align: left;
+  body {
+    padding: 0.5rem;
   }
 
-  .focus-card__glyph {
-    justify-self: flex-start;
+  .sidebar__hero h1 {
+    font-size: 1.6rem;
+  }
+
+  .panel,
+  .sidebar__hero {
+    padding: 1rem;
+  }
+
+  .sidebar {
+    gap: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a dark/light theme toggle with persistence and accessibility hints so the board can swap between light and dark palettes
- refresh the laser chess board and interface styling with theme-driven colors, overlays, and piece glows to improve the Slavonic atmosphere on mobile and desktop

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_690204e288e88320a338d9ffe8610b0f