### PR TITLE
Enable diagonal totem swaps and load piece images

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@
       <section class="panel panel--legend">
         <h2>Легенда орденов</h2>
         <ul class="legend">
-          <li><span class="legend__glyph legend__glyph--light">☼</span> Лучезар (излучает лазер)</li>
-          <li><span class="legend__glyph legend__glyph--light">✧</span> Волхв (главная цель)</li>
-          <li><span class="legend__glyph legend__glyph--light">◩</span> Зерцало (одна отражающая грань)</li>
-          <li><span class="legend__glyph legend__glyph--light">🛡</span> Щитоносец (останавливает луч щитом)</li>
-          <li><span class="legend__glyph legend__glyph--light">⟁</span> Тотем (двойное зерцало, меняется местами с союзниками)</li>
+          <li><span class="legend__glyph legend__glyph--light"><img src="pieces/laser.png" alt=""></span> Лучезар (излучает лазер)</li>
+          <li><span class="legend__glyph legend__glyph--light"><img src="pieces/volhv.png" alt=""></span> Волхв (главная цель)</li>
+          <li><span class="legend__glyph legend__glyph--light"><img src="pieces/mirror.png" alt=""></span> Зерцало (одна отражающая грань)</li>
+          <li><span class="legend__glyph legend__glyph--light"><img src="pieces/shield.png" alt=""></span> Щитоносец (останавливает луч щитом)</li>
+          <li><span class="legend__glyph legend__glyph--light"><img src="pieces/totem.png" alt=""></span> Тотем (двойное зерцало, меняется местами с союзниками, включая диагональ)</li>
         </ul>
       </section>
     </aside>

--- a/script.js
+++ b/script.js
@@ -43,40 +43,42 @@ const PLAYERS = {
   }
 };
 
+// Поместите файлы PNG (laser.png, volhv.png, mirror.png, shield.png, totem.png)
+// в папку "pieces" рядом со script.js.
 const PIECE_DEFS = {
   laser: {
     name: "Лучезар",
-    glyph: "☼",
+    image: "pieces/laser.png",
     canRotate: true,
     description: "Излучает луч. Не двигается и неуязвим, можно лишь поворачивать направление луча.",
     movement: () => []
   },
   volhv: {
     name: "Волхв",
-    glyph: "✧",
+    image: "pieces/volhv.png",
     canRotate: false,
     description: "Главная фигура. Ходит на одну клетку в любом направлении. Попадание луча заканчивает партию.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   mirror: {
     name: "Зерцало",
-    glyph: "◩",
+    image: "pieces/mirror.png",
     canRotate: true,
     description: "Один зеркальный фас. Отражает луч под прямым углом, уязвимо с открытых сторон.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   shield: {
     name: "Щитоносец",
-    glyph: "🛡",
+    image: "pieces/shield.png",
     canRotate: true,
     description: "Щит гасит луч лицевой стороной. С боков и тыла может быть уничтожен.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   totem: {
     name: "Тотем",
-    glyph: "✖️",
+    image: "pieces/totem.png",
     canRotate: true,
-    description: "Двуликое зеркало. Отражает с двух сторон и может сменяться местами с зерцалом или щитом поблизости.",
+    description: "Двуликое зеркало. Отражает с двух сторон и может сменяться местами с зерцалом или щитом поблизости, включая диагональ.",
     movement: (board, x, y, piece) => totemMoves(board, x, y, piece)
   }
 };
@@ -203,11 +205,12 @@ function renderBoard() {
         const def = PIECE_DEFS[piece.type];
         const wrapper = document.createElement("div");
         wrapper.className = `piece piece--${piece.player}`;
-        const glyph = document.createElement("span");
-        glyph.textContent = def.glyph;
-        glyph.className = "piece__glyph";
-        glyph.style.transform = `rotate(${piece.orientation * 90}deg)`;
-        wrapper.appendChild(glyph);
+        const image = document.createElement("img");
+        image.src = def.image;
+        image.alt = "";
+        image.className = "piece__image";
+        image.style.transform = `rotate(${piece.orientation * 90}deg)`;
+        wrapper.appendChild(image);
         wrapper.setAttribute("aria-label", `${def.name} (${PLAYERS[piece.player].name})`);
         cell.replaceChildren(wrapper);
       } else {
@@ -582,7 +585,7 @@ function adjacentMoves(boardState, x, y, piece) {
 
 function totemMoves(boardState, x, y, piece) {
   const moves = adjacentMoves(boardState, x, y, piece);
-  for (const dir of DIRECTIONS) {
+  for (const dir of ADJACENT) {
     const nx = x + dir.dx;
     const ny = y + dir.dy;
     if (!inBounds(nx, ny)) continue;

--- a/style.css
+++ b/style.css
@@ -354,9 +354,20 @@ body.theme-light .piece {
   opacity: 0.82;
 }
 
-.piece__glyph {
-  display: inline-block;
+.piece__image {
+  display: block;
+  width: 68%;
+  max-width: 72px;
+  pointer-events: none;
+  user-select: none;
   transition: transform 0.2s ease;
+}
+
+.legend__glyph img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .status {


### PR DESCRIPTION
## Summary
- allow totems to swap with adjacent ally mirrors or shields in all directions
- render pieces and legend entries with PNG assets instead of inline glyphs

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_6903655c839c8320815cee0b079d0f33