### PR TITLE
Adjust responsive styling for varying screen widths

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,12 +14,13 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: var(--font-family);
+  font-size: 1rem;
   background: var(--page-gradient, var(--bg));
   color: var(--text);
   display: flex;
   justify-content: center;
-  padding: 1rem;
-  transition: background 0.6s ease, color 0.4s ease;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+  transition: background 0.6s ease, color 0.4s ease, font-size 0.3s ease;
   position: relative;
   overflow-x: hidden;
 }
@@ -119,7 +120,7 @@ body > * {
 }
 
 .game {
-  width: min(1100px, 100%);
+  width: min(100%, clamp(760px, 85vw, 1100px));
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(0, 1fr) 280px;
@@ -242,7 +243,7 @@ body.theme-light .button--primary {
   display: grid;
   grid-template-columns: repeat(var(--board-columns, 8), minmax(0, 1fr));
   grid-auto-rows: 1fr;
-  width: min(900px, 96vw);
+  width: clamp(320px, 92vw, 720px);
   aspect-ratio: var(--board-columns, 8) / var(--board-rows, 8);
   border-radius: 18px;
   overflow: hidden;
@@ -356,8 +357,8 @@ body.theme-light .piece {
 
 .piece__image {
   display: block;
-  width: 68%;
-  max-width: 72px;
+  width: clamp(56%, calc(60% + 1vw), 68%);
+  max-width: clamp(64px, 8vw, 80px);
   pointer-events: none;
   user-select: none;
   transition: transform 0.2s ease;
@@ -564,10 +565,6 @@ body.theme-light .board-action {
 }
 
 @media (max-width: 960px) {
-  body {
-    padding: 0.75rem;
-  }
-
   .game {
     grid-template-columns: 1fr;
   }
@@ -598,15 +595,67 @@ body.theme-light .board-action {
 }
 
 @media (max-width: 540px) {
-  body {
-    padding: 0.5rem;
-  }
-
   .panel {
     padding: 1rem;
   }
 
   .sidebar {
     gap: 0.5rem;
+  }
+
+  .board-toolbar {
+    width: 100%;
+  }
+
+  .board-actions {
+    gap: 0.5rem;
+  }
+
+  .board-action {
+    width: 3.1rem;
+    height: 3.1rem;
+    font-size: 1.3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 1.05rem;
+  }
+
+  .panel {
+    flex-basis: min(320px, 100%);
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    font-size: 1.12rem;
+  }
+
+  .game {
+    gap: 0.75rem;
+  }
+
+  .board-area {
+    gap: 0.75rem;
+  }
+
+  .panel {
+    padding: 0.9rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .board {
+    max-width: 680px;
+  }
+
+  .panel {
+    padding: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust the page padding and base font size so the layout scales with the viewport
- constrain the board and piece sizing for better balance on both small and large displays
- refine responsive breakpoints to enlarge controls on phones and tighten spacing on wide screens

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6903a82f115c8320afecf665f433cc08