### PR TITLE
Expand piece assets per faction and fill board tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,40 +43,55 @@ const PLAYERS = {
   }
 };
 
-// Поместите файлы PNG (laser.png, volhv.png, mirror.png, shield.png, totem.png)
-// в папку "pieces" рядом со script.js.
+// Поместите файлы PNG для каждой фракции в подпапки "pieces/light" и "pieces/shadow"
+// рядом со script.js. Например: pieces/light/laser.png, pieces/shadow/laser.png и т.д.
 const PIECE_DEFS = {
   laser: {
     name: "Лучезар",
-    image: "pieces/laser.png",
+    images: {
+      light: "pieces/light/laser.png",
+      shadow: "pieces/shadow/laser.png"
+    },
     canRotate: true,
     description: "Излучает луч. Не двигается и неуязвим, можно лишь поворачивать направление луча.",
     movement: () => []
   },
   volhv: {
     name: "Волхв",
-    image: "pieces/volhv.png",
+    images: {
+      light: "pieces/light/volhv.png",
+      shadow: "pieces/shadow/volhv.png"
+    },
     canRotate: false,
     description: "Главная фигура. Ходит на одну клетку в любом направлении. Попадание луча заканчивает партию.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   mirror: {
     name: "Зерцало",
-    image: "pieces/mirror.png",
+    images: {
+      light: "pieces/light/mirror.png",
+      shadow: "pieces/shadow/mirror.png"
+    },
     canRotate: true,
     description: "Один зеркальный фас. Отражает луч под прямым углом, уязвимо с открытых сторон.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   shield: {
     name: "Щитоносец",
-    image: "pieces/shield.png",
+    images: {
+      light: "pieces/light/shield.png",
+      shadow: "pieces/shadow/shield.png"
+    },
     canRotate: true,
     description: "Щит гасит луч лицевой стороной. С боков и тыла может быть уничтожен.",
     movement: (board, x, y, piece) => adjacentMoves(board, x, y, piece)
   },
   totem: {
     name: "Тотем",
-    image: "pieces/totem.png",
+    images: {
+      light: "pieces/light/totem.png",
+      shadow: "pieces/shadow/totem.png"
+    },
     canRotate: true,
     description: "Двуликое зеркало. Отражает с двух сторон и может сменяться местами с зерцалом или щитом поблизости, включая диагональ.",
     movement: (board, x, y, piece) => totemMoves(board, x, y, piece)
@@ -206,7 +221,7 @@ function renderBoard() {
         const wrapper = document.createElement("div");
         wrapper.className = `piece piece--${piece.player}`;
         const image = document.createElement("img");
-        image.src = def.image;
+        image.src = def.images[piece.player];
         image.alt = "";
         image.className = "piece__image";
         image.style.transform = `rotate(${piece.orientation * 90}deg)`;

--- a/style.css
+++ b/style.css
@@ -14,12 +14,13 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: var(--font-family);
+  font-size: 1rem;
   background: var(--page-gradient, var(--bg));
   color: var(--text);
   display: flex;
   justify-content: center;
-  padding: 1rem;
-  transition: background 0.6s ease, color 0.4s ease;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+  transition: background 0.6s ease, color 0.4s ease, font-size 0.3s ease;
   position: relative;
   overflow-x: hidden;
 }
@@ -119,7 +120,7 @@ body > * {
 }
 
 .game {
-  width: min(1100px, 100%);
+  width: min(100%, clamp(760px, 85vw, 1100px));
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(0, 1fr) 280px;
@@ -242,7 +243,7 @@ body.theme-light .button--primary {
   display: grid;
   grid-template-columns: repeat(var(--board-columns, 8), minmax(0, 1fr));
   grid-auto-rows: 1fr;
-  width: min(900px, 96vw);
+  width: clamp(320px, 92vw, 720px);
   aspect-ratio: var(--board-columns, 8) / var(--board-rows, 8);
   border-radius: 18px;
   overflow: hidden;
@@ -356,11 +357,15 @@ body.theme-light .piece {
 
 .piece__image {
   display: block;
-  width: 68%;
-  max-width: 72px;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  object-fit: contain;
   pointer-events: none;
   user-select: none;
   transition: transform 0.2s ease;
+  transform-origin: center;
 }
 
 .legend__glyph img {
@@ -564,10 +569,6 @@ body.theme-light .board-action {
 }
 
 @media (max-width: 960px) {
-  body {
-    padding: 0.75rem;
-  }
-
   .game {
     grid-template-columns: 1fr;
   }
@@ -598,15 +599,67 @@ body.theme-light .board-action {
 }
 
 @media (max-width: 540px) {
-  body {
-    padding: 0.5rem;
-  }
-
   .panel {
     padding: 1rem;
   }
 
   .sidebar {
     gap: 0.5rem;
+  }
+
+  .board-toolbar {
+    width: 100%;
+  }
+
+  .board-actions {
+    gap: 0.5rem;
+  }
+
+  .board-action {
+    width: 3.1rem;
+    height: 3.1rem;
+    font-size: 1.3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 1.05rem;
+  }
+
+  .panel {
+    flex-basis: min(320px, 100%);
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    font-size: 1.12rem;
+  }
+
+  .game {
+    gap: 0.75rem;
+  }
+
+  .board-area {
+    gap: 0.75rem;
+  }
+
+  .panel {
+    padding: 0.9rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .board {
+    max-width: 680px;
+  }
+
+  .panel {
+    padding: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- reference distinct image paths for each faction's pieces
- stretch board piece artwork to fill the tile area

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6903a82f115c8320afecf665f433cc08