### PR TITLE
Icon size to fit file

### DIFF
--- a/style.css
+++ b/style.css
@@ -357,12 +357,14 @@ body.theme-light .piece {
 
 .piece__image {
   display: block;
-  width: clamp(56%, calc(60% + 1vw), 68%);
-  max-width: clamp(64px, 8vw, 80px);
+  width: 100%;
+  height: 100%;
+  max-width: none;
   pointer-events: none;
   user-select: none;
   transition: transform 0.2s ease;
   transform-origin: center;
+  object-fit: contain;
 }
 
 .legend__glyph img {


### PR DESCRIPTION
## Summary
- expand piece image styling so icons fill the entire board cell while keeping aspect ratio

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690482a8a4788320bb61689347bf876a