### PR TITLE
Add multiplayer support with WebSocket server

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,64 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="theme-dark">
+  <div id="connection-overlay" class="connection-overlay" role="dialog" aria-modal="true" aria-labelledby="connection-title">
+    <form id="connection-form" class="connection-card" autocomplete="off">
+      <h1 id="connection-title" class="connection-card__title">Сетевая партия</h1>
+      <p class="connection-card__intro">Выберите комнату и сторону, чтобы сыграть вдвоём. Второй игрок должен указать тот же идентификатор комнаты.</p>
+
+      <label class="connection-field">
+        <span class="connection-field__label">Адрес сервера</span>
+        <input id="server-url" name="server" type="text" class="connection-field__input" required value="ws://localhost:8787" spellcheck="false">
+      </label>
+
+      <label class="connection-field">
+        <span class="connection-field__label">Комната</span>
+        <input id="room-id" name="room" type="text" class="connection-field__input" required placeholder="Например, perun" maxlength="32" spellcheck="false">
+      </label>
+
+      <fieldset class="connection-fieldset">
+        <legend class="connection-fieldset__legend">Ваша сторона</legend>
+        <label class="connection-role">
+          <input type="radio" name="role" value="light" required>
+          <span class="connection-role__content">
+            <span class="connection-role__glyph">☼</span>
+            <span class="connection-role__label">Дружина Перуна</span>
+          </span>
+        </label>
+        <label class="connection-role">
+          <input type="radio" name="role" value="shadow" required>
+          <span class="connection-role__content">
+            <span class="connection-role__glyph">☽</span>
+            <span class="connection-role__label">Полк Чернобога</span>
+          </span>
+        </label>
+      </fieldset>
+
+      <ul id="connection-players" class="connection-players" aria-live="polite">
+        <li class="connection-players__item" data-role="light">
+          <span class="connection-players__name">☼ Дружина Перуна</span>
+          <span class="connection-players__status">свободно</span>
+        </li>
+        <li class="connection-players__item" data-role="shadow">
+          <span class="connection-players__name">☽ Полк Чернобога</span>
+          <span class="connection-players__status">свободно</span>
+        </li>
+      </ul>
+
+      <p id="connection-status" class="connection-status" role="status"></p>
+
+      <div class="connection-actions">
+        <button type="submit" id="connect-button" class="button button--primary">Подключиться</button>
+        <button type="button" id="offline-button" class="button button--ghost">Играть офлайн</button>
+      </div>
+    </form>
+  </div>
+
   <main class="game">
     <section class="board-area">
       <div class="board-toolbar">
         <button type="button" id="new-game" class="toolbar-button toolbar-button--primary" title="Начать заново">New</button>
+        <button type="button" id="open-connection" class="toolbar-button" title="Настройки мультиплеера">Сеть</button>
         <button type="button" id="theme-toggle" class="toolbar-button toolbar-button--icon" aria-pressed="false" aria-label="Переключить тему">
           <span aria-hidden="true">🌙</span>
         </button>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mazepark",
+  "version": "1.0.0",
+  "description": "Laser duel multiplayer server and client",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "ws": "^8.14.2"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -134,6 +134,8 @@ let selectedCell = null;
 let currentOptions = [];
 let turnCounter = 1;
 let currentTheme = "dark";
+let lastStatusMessage = "";
+let lastLaserResult = null;
 
 const elements = {
   board: document.getElementById("board"),
@@ -146,16 +148,27 @@ const elements = {
   endgameSubtitle: document.getElementById("endgame-subtitle"),
   playAgain: document.getElementById("play-again"),
   themeToggle: document.getElementById("theme-toggle"),
+  openConnection: document.getElementById("open-connection"),
   laserOverlay: document.getElementById("laser-overlay"),
   pieceName: document.getElementById("piece-name"),
-  pieceDetails: document.getElementById("piece-details")
+  pieceDetails: document.getElementById("piece-details"),
+  connectionOverlay: document.getElementById("connection-overlay"),
+  connectionForm: document.getElementById("connection-form"),
+  connectionStatus: document.getElementById("connection-status"),
+  connectionPlayers: document.getElementById("connection-players"),
+  connectButton: document.getElementById("connect-button"),
+  offlineButton: document.getElementById("offline-button"),
+  serverInput: document.getElementById("server-url"),
+  roomInput: document.getElementById("room-id")
 };
 
 const cells = [];
+const multiplayer = createMultiplayerController();
 
 initialiseBoardGrid();
 attachEventListeners();
 initialiseTheme();
+multiplayer.init();
 startNewGame();
 
 function startNewGame() {
@@ -169,6 +182,7 @@ function startNewGame() {
   setStatus("Дружина Перуна начинает дуэль: выберите фигуру или поверните зеркало.");
   elements.endgame.hidden = true;
   elements.endgame.setAttribute("aria-hidden", "true");
+  broadcastGameState("new-game");
 }
 
 function createEmptyBoard() {
@@ -220,6 +234,22 @@ function attachEventListeners() {
   if (elements.themeToggle) {
     elements.themeToggle.addEventListener("click", toggleTheme);
   }
+  if (elements.connectionForm) {
+    elements.connectionForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      multiplayer.handleConnectSubmission();
+    });
+  }
+  if (elements.offlineButton) {
+    elements.offlineButton.addEventListener("click", () => {
+      multiplayer.handleOfflineSelection();
+    });
+  }
+  if (elements.openConnection) {
+    elements.openConnection.addEventListener("click", () => {
+      multiplayer.openOverlay();
+    });
+  }
 }
 
 function renderBoard() {
@@ -258,6 +288,14 @@ function renderBoard() {
 
 function handleCellInteraction(x, y) {
   if (elements.endgame.hidden === false) return;
+  if (!multiplayer.canAct()) {
+    if (multiplayer.isWaitingForOpponent()) {
+      setStatus("Ожидаем подключения второго игрока.");
+    } else if (multiplayer.isActive()) {
+      setStatus(`${PLAYERS[currentPlayer].name}: сейчас ход соперника.`);
+    }
+    return;
+  }
 
   const piece = board[y][x];
   const current = selectedCell ? board[selectedCell.y][selectedCell.x] : null;
@@ -308,7 +346,12 @@ function clearSelection({ silent = false } = {}) {
 
 function updateRotateControls(enabled) {
   const piece = selectedCell ? board[selectedCell.y][selectedCell.x] : null;
-  const canRotate = Boolean(enabled && piece && piece.player === currentPlayer);
+  const canRotate = Boolean(
+    enabled &&
+    piece &&
+    piece.player === currentPlayer &&
+    multiplayer.canAct()
+  );
   elements.rotateLeft.disabled = !canRotate;
   elements.rotateRight.disabled = !canRotate;
 }
@@ -324,6 +367,7 @@ function executeMove(option, piece, from) {
     board[option.y][option.x] = piece;
     setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} меняется местами с ${PIECE_DEFS[targetPiece.type].name} на ${toNotation(option.x, option.y)}.`);
     endTurn();
+    broadcastGameState("swap");
     return;
   }
 
@@ -338,6 +382,7 @@ function executeMove(option, piece, from) {
   setStatus(`${PLAYERS[currentPlayer].name}: ${PIECE_DEFS[piece.type].name} перемещён на ${toNotation(option.x, option.y)}.`);
 
   endTurn();
+  broadcastGameState(option.swap ? "swap" : "move");
 }
 
 function rotateSelected(delta) {
@@ -345,18 +390,26 @@ function rotateSelected(delta) {
   const piece = board[selectedCell.y][selectedCell.x];
   const def = PIECE_DEFS[piece.type];
   if (!def.canRotate || piece.player !== currentPlayer) return;
+  if (!multiplayer.canAct()) {
+    if (multiplayer.isActive()) {
+      setStatus(`${PLAYERS[currentPlayer].name}: сейчас ход соперника.`);
+    }
+    return;
+  }
 
   piece.orientation = mod4(piece.orientation + delta);
   renderBoard();
   const dirSymbol = delta > 0 ? "↻" : "↺";
   setStatus(`${PLAYERS[currentPlayer].name}: ${def.name} на ${toNotation(selectedCell.x, selectedCell.y)} повёрнут ${delta > 0 ? "по" : "против"} часовой стрелки.`);
   endTurn();
+  broadcastGameState(delta > 0 ? "rotate-cw" : "rotate-ccw");
 }
 
 function endTurn() {
   clearSelection({ silent: true });
   const activePlayer = currentPlayer;
-  const laserResult = fireLaser(activePlayer);
+  const laserResult = normaliseLaserResult(fireLaser(activePlayer));
+  lastLaserResult = laserResult;
   renderBoard();
   highlightLaserPath(laserResult);
   if (laserResult.hit) {
@@ -522,7 +575,7 @@ function findEmitter(player) {
 }
 
 function highlightLaserPath(result) {
-  clearLaserPath();
+  clearLaserPath({ preserveState: true });
   if (!result || !result.origin) {
     return;
   }
@@ -530,9 +583,12 @@ function highlightLaserPath(result) {
   drawLaserBeam(result);
 }
 
-function clearLaserPath() {
+function clearLaserPath({ preserveState = false } = {}) {
   if (elements.laserOverlay) {
     elements.laserOverlay.replaceChildren();
+  }
+  if (!preserveState) {
+    lastLaserResult = null;
   }
 }
 
@@ -648,7 +704,10 @@ function updateTurnIndicator() {
 }
 
 function setStatus(message) {
-  elements.status.textContent = message;
+  lastStatusMessage = message;
+  if (elements.status) {
+    elements.status.textContent = message;
+  }
 }
 
 function initialiseTheme() {
@@ -718,4 +777,417 @@ function orientationToText(orientation) {
     default:
       return "к западу";
   }
+}
+
+function normaliseLaserResult(result) {
+  if (!result) {
+    return null;
+  }
+  const copy = {
+    firer: result.firer,
+    origin: result.origin ? { x: result.origin.x, y: result.origin.y } : null,
+    path: Array.isArray(result.path)
+      ? result.path.map(({ x, y }) => ({ x, y }))
+      : [],
+    termination: result.termination
+      ? { x: result.termination.x, y: result.termination.y }
+      : null
+  };
+  if (result.hit) {
+    copy.hit = {
+      x: result.hit.x,
+      y: result.hit.y,
+      piece: result.hit.piece ? clonePiece(result.hit.piece) : null
+    };
+  }
+  if (result.blocked) {
+    copy.blocked = {
+      x: result.blocked.x,
+      y: result.blocked.y,
+      piece: result.blocked.piece ? clonePiece(result.blocked.piece) : null
+    };
+  }
+  return copy;
+}
+
+function clonePiece(piece) {
+  if (!piece) {
+    return null;
+  }
+  return {
+    type: piece.type,
+    player: piece.player,
+    orientation: mod4(piece.orientation || 0)
+  };
+}
+
+function cloneBoardState(boardState) {
+  const next = createEmptyBoard();
+  if (!Array.isArray(boardState)) {
+    return next;
+  }
+  for (let y = 0; y < Math.min(boardState.length, BOARD_HEIGHT); y += 1) {
+    const row = boardState[y];
+    if (!Array.isArray(row)) continue;
+    for (let x = 0; x < Math.min(row.length, BOARD_WIDTH); x += 1) {
+      const piece = row[x];
+      next[y][x] = piece ? clonePiece(piece) : null;
+    }
+  }
+  return next;
+}
+
+function serialiseGameState() {
+  return {
+    board: cloneBoardState(board),
+    currentPlayer,
+    turnCounter,
+    status: lastStatusMessage,
+    endgame: {
+      visible: elements.endgame ? elements.endgame.hidden === false : false,
+      title: elements.endgameTitle ? elements.endgameTitle.textContent : "",
+      subtitle: elements.endgameSubtitle ? elements.endgameSubtitle.textContent : ""
+    },
+    laser: lastLaserResult ? normaliseLaserResult(lastLaserResult) : null
+  };
+}
+
+function applyRemoteState(state) {
+  if (!state) return;
+  multiplayer.suppress(() => {
+    board = cloneBoardState(state.board);
+    currentPlayer = state.currentPlayer === "shadow" ? "shadow" : "light";
+    if (typeof state.turnCounter === "number" && Number.isFinite(state.turnCounter)) {
+      turnCounter = state.turnCounter;
+    }
+    clearSelection({ silent: true });
+    updateTurnIndicator();
+    if (state.endgame && state.endgame.visible) {
+      elements.endgame.hidden = false;
+      elements.endgame.setAttribute("aria-hidden", "false");
+      if (elements.endgameTitle) {
+        elements.endgameTitle.textContent = state.endgame.title || "";
+      }
+      if (elements.endgameSubtitle) {
+        elements.endgameSubtitle.textContent = state.endgame.subtitle || "";
+      }
+    } else {
+      elements.endgame.hidden = true;
+      elements.endgame.setAttribute("aria-hidden", "true");
+    }
+    if (typeof state.status === "string") {
+      setStatus(state.status);
+    } else if (multiplayer.canAct()) {
+      setStatus(`${PLAYERS[currentPlayer].name}: выберите фигуру.`);
+    }
+    lastLaserResult = state.laser ? normaliseLaserResult(state.laser) : null;
+    if (lastLaserResult) {
+      highlightLaserPath(lastLaserResult);
+    } else {
+      clearLaserPath();
+    }
+  });
+}
+
+function broadcastGameState(reason) {
+  if (!multiplayer.canBroadcast()) {
+    return;
+  }
+  multiplayer.sendState(reason, serialiseGameState());
+}
+
+function createMultiplayerController() {
+  const state = {
+    ws: null,
+    connected: false,
+    role: null,
+    roomId: null,
+    serverUrl: null,
+    players: { light: false, shadow: false },
+    suppressDepth: 0
+  };
+
+  function init() {
+    if (!elements.connectionOverlay) {
+      return;
+    }
+    showOverlay();
+    updatePlayersUI();
+    const defaultUrl = deriveDefaultServerUrl();
+    if (elements.serverInput && !elements.serverInput.value) {
+      elements.serverInput.value = defaultUrl;
+    }
+    setOverlayStatus("Подключитесь к комнате или продолжите офлайн.");
+    window.addEventListener("beforeunload", () => {
+      cleanupSocket(true);
+    });
+  }
+
+  function handleConnectSubmission() {
+    if (!elements.connectionForm) return;
+    const formData = new FormData(elements.connectionForm);
+    const server = (formData.get("server") || "").toString().trim();
+    const room = (formData.get("room") || "").toString().trim().toLowerCase();
+    const role = (formData.get("role") || "").toString();
+    if (!server) {
+      setOverlayStatus("Укажите адрес сервера.");
+      return;
+    }
+    if (!room || room.length < 2) {
+      setOverlayStatus("Название комнаты должно содержать минимум 2 символа.");
+      return;
+    }
+    if (role !== "light" && role !== "shadow") {
+      setOverlayStatus("Выберите сторону для игры.");
+      return;
+    }
+    state.role = role;
+    updatePlayersUI();
+    connectToServer(server, room, role);
+  }
+
+  function handleOfflineSelection() {
+    cleanupSocket(true);
+    resetConnectionState();
+    hideOverlay();
+    setOverlayStatus("");
+  }
+
+  function connectToServer(serverUrl, roomId, role) {
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(serverUrl);
+    } catch (err) {
+      setOverlayStatus("Некорректный адрес сервера.");
+      return;
+    }
+    if (parsedUrl.protocol !== "ws:" && parsedUrl.protocol !== "wss:") {
+      setOverlayStatus("Используйте протокол ws:// или wss://.");
+      return;
+    }
+
+    cleanupSocket(true);
+    setFormDisabled(true);
+    setOverlayStatus("Подключение...");
+
+    state.serverUrl = parsedUrl.toString();
+    state.roomId = roomId;
+
+    const ws = new WebSocket(state.serverUrl);
+    state.ws = ws;
+
+    ws.onopen = () => {
+      setOverlayStatus("Соединение установлено. Ожидаем подтверждения...");
+      send({ type: "join", roomId, role });
+    };
+    ws.onmessage = (event) => {
+      handleMessage(event);
+    };
+    ws.onerror = () => {
+      setOverlayStatus("Не удалось установить соединение.");
+    };
+    ws.onclose = (event) => {
+      const reason = event.wasClean ? "Соединение закрыто." : "Соединение потеряно.";
+      handleSocketClosure(reason);
+    };
+  }
+
+  function handleMessage(event) {
+    let payload;
+    try {
+      payload = JSON.parse(event.data);
+    } catch (err) {
+      return;
+    }
+
+    switch (payload.type) {
+      case "joined":
+        state.connected = true;
+        setFormDisabled(false);
+        hideOverlay();
+        updatePlayers(payload.players);
+        if (payload.state) {
+          applyRemoteState(payload.state);
+        } else {
+          broadcastGameState("sync");
+        }
+        if (typeof payload.message === "string" && payload.message) {
+          setStatus(payload.message);
+        }
+        break;
+      case "players":
+        updatePlayers(payload.players);
+        break;
+      case "state":
+        if (payload.state) {
+          applyRemoteState(payload.state);
+        }
+        if (payload.players) {
+          updatePlayers(payload.players);
+        }
+        break;
+      case "error":
+        setOverlayStatus(payload.message || "Сервер отклонил подключение.");
+        handleSocketClosure("Соединение закрыто.");
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleSocketClosure(message) {
+    const wasConnected = state.connected;
+    cleanupSocket(true);
+    resetConnectionState();
+    showOverlay();
+    setFormDisabled(false);
+    if (message) {
+      setOverlayStatus(message);
+    }
+    if (wasConnected) {
+      setStatus("Соединение с сервером потеряно. Игра продолжается локально.");
+    }
+  }
+
+  function updatePlayers(players) {
+    state.players = {
+      light: Boolean(players && players.light),
+      shadow: Boolean(players && players.shadow)
+    };
+    if (state.connected && state.role) {
+      state.players[state.role] = true;
+    }
+    updatePlayersUI();
+  }
+
+  function updatePlayersUI() {
+    if (!elements.connectionPlayers) return;
+    const items = elements.connectionPlayers.querySelectorAll("[data-role]");
+    items.forEach((item) => {
+      const role = item.dataset.role;
+      const occupied = Boolean(state.players[role]);
+      item.classList.toggle("connection-players__item--occupied", occupied);
+      item.classList.toggle("connection-players__item--self", state.role === role && state.connected);
+      const statusEl = item.querySelector(".connection-players__status");
+      if (statusEl) {
+        if (occupied) {
+          statusEl.textContent = state.role === role && state.connected ? "вы" : "занято";
+        } else {
+          statusEl.textContent = "свободно";
+        }
+      }
+    });
+  }
+
+  function setOverlayStatus(message) {
+    if (elements.connectionStatus) {
+      elements.connectionStatus.textContent = message;
+    }
+  }
+
+  function showOverlay() {
+    if (!elements.connectionOverlay) return;
+    elements.connectionOverlay.hidden = false;
+    elements.connectionOverlay.setAttribute("aria-hidden", "false");
+  }
+
+  function hideOverlay() {
+    if (!elements.connectionOverlay) return;
+    elements.connectionOverlay.hidden = true;
+    elements.connectionOverlay.setAttribute("aria-hidden", "true");
+  }
+
+  function setFormDisabled(disabled) {
+    if (!elements.connectionForm) return;
+    const controls = elements.connectionForm.querySelectorAll("input, button");
+    controls.forEach((control) => {
+      if (control.id === "offline-button") return;
+      control.disabled = disabled;
+    });
+  }
+
+  function openOverlay() {
+    showOverlay();
+    updatePlayersUI();
+    const roleName = state.role && PLAYERS[state.role] ? PLAYERS[state.role].name : null;
+    const message = state.connected
+      ? `Соединение активно${roleName ? `: вы играете за «${roleName}».` : "."}`
+      : "Подключитесь к комнате или продолжите офлайн.";
+    setOverlayStatus(message);
+    setFormDisabled(false);
+  }
+
+  function cleanupSocket(silent = false) {
+    if (!state.ws) return;
+    const ws = state.ws;
+    state.ws = null;
+    if (silent) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+    }
+    try {
+      ws.close();
+    } catch (err) {
+      // игнорируем ошибки закрытия
+    }
+  }
+
+  function resetConnectionState() {
+    state.connected = false;
+    state.roomId = null;
+    state.players = { light: false, shadow: false };
+    updatePlayersUI();
+  }
+
+  function send(payload) {
+    if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    state.ws.send(JSON.stringify(payload));
+  }
+
+  function deriveDefaultServerUrl() {
+    const { protocol, hostname, port } = window.location;
+    if (protocol === "http:" || protocol === "https:") {
+      const scheme = protocol === "https:" ? "wss" : "ws";
+      const host = hostname || "localhost";
+      if (port) {
+        return `${scheme}://${host}:${port}`;
+      }
+      return `${scheme}://${host}${scheme === "ws" ? ":8787" : ""}`;
+    }
+    return "ws://localhost:8787";
+  }
+
+  return {
+    init,
+    handleConnectSubmission,
+    handleOfflineSelection,
+    openOverlay,
+    sendState(reason, statePayload) {
+      send({ type: "state", roomId: state.roomId, role: state.role, reason, state: statePayload });
+    },
+    canBroadcast() {
+      return Boolean(state.connected && state.ws && state.ws.readyState === WebSocket.OPEN && state.suppressDepth === 0);
+    },
+    suppress(callback) {
+      state.suppressDepth += 1;
+      try {
+        callback();
+      } finally {
+        state.suppressDepth = Math.max(0, state.suppressDepth - 1);
+      }
+    },
+    canAct() {
+      return !state.connected || state.role === currentPlayer;
+    },
+    isActive() {
+      return state.connected;
+    },
+    isWaitingForOpponent() {
+      return state.connected && !(state.players.light && state.players.shadow);
+    }
+  };
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,195 @@
+const http = require("http");
+const { WebSocketServer } = require("ws");
+
+const PORT = Number(process.env.PORT || 8787);
+
+const rooms = new Map();
+
+const server = http.createServer();
+const wss = new WebSocketServer({ server });
+
+wss.on("connection", (socket) => {
+  socket.isAlive = true;
+  socket.on("pong", () => {
+    socket.isAlive = true;
+  });
+
+  let membership = null;
+
+  socket.on("message", (data) => {
+    let payload;
+    try {
+      payload = JSON.parse(data.toString());
+    } catch (err) {
+      return;
+    }
+
+    if (!payload || typeof payload.type !== "string") {
+      return;
+    }
+
+    if (payload.type === "join") {
+      handleJoin(socket, payload);
+      return;
+    }
+
+    if (!membership) {
+      send(socket, { type: "error", message: "Сначала выберите комнату и сторону." });
+      return;
+    }
+
+    if (payload.type === "state") {
+      handleStateUpdate(membership, payload);
+    }
+  });
+
+  socket.on("close", () => {
+    if (!membership) return;
+    const room = rooms.get(membership.roomId);
+    if (!room) return;
+    const current = room.clients.get(membership.role);
+    if (current === socket) {
+      room.clients.delete(membership.role);
+      broadcastPlayers(membership.roomId);
+      if (room.clients.size === 0) {
+        rooms.delete(membership.roomId);
+      }
+    }
+  });
+
+  socket.on("error", () => {
+    // ошибки соединения игнорируются, закрытие обработает onclose
+  });
+
+  function handleJoin(ws, payload) {
+    if (membership) {
+      send(ws, { type: "error", message: "Повторное подключение запрещено." });
+      return;
+    }
+    const roomId = normaliseRoomId(payload.roomId);
+    const role = typeof payload.role === "string" ? payload.role.trim().toLowerCase() : "";
+    if (!roomId) {
+      send(ws, { type: "error", message: "Некорректное название комнаты." });
+      return;
+    }
+    if (role !== "light" && role !== "shadow") {
+      send(ws, { type: "error", message: "Выберите сторону: light или shadow." });
+      return;
+    }
+
+    const room = getRoom(roomId);
+    if (room.clients.has(role)) {
+      send(ws, { type: "error", message: "Эта сторона уже занята." });
+      return;
+    }
+
+    room.clients.set(role, ws);
+    membership = { roomId, role };
+
+    send(ws, {
+      type: "joined",
+      roomId,
+      role,
+      players: getPlayersSnapshot(roomId),
+      state: room.state,
+      message: `Подключено к комнате ${roomId}.`
+    });
+
+    broadcastPlayers(roomId);
+  }
+
+  function handleStateUpdate(member, payload) {
+    const room = rooms.get(member.roomId);
+    if (!room || room.clients.get(member.role) !== socket) {
+      return;
+    }
+    if (!payload.state || typeof payload.state !== "object") {
+      return;
+    }
+    room.state = payload.state;
+    const message = {
+      type: "state",
+      state: room.state,
+      players: getPlayersSnapshot(member.roomId),
+      author: member.role
+    };
+    if (typeof payload.reason === "string" && payload.reason) {
+      message.reason = payload.reason;
+    }
+    broadcast(member.roomId, message);
+  }
+});
+
+const heartbeat = setInterval(() => {
+  for (const socket of wss.clients) {
+    if (socket.isAlive === false) {
+      socket.terminate();
+      continue;
+    }
+    socket.isAlive = false;
+    socket.ping();
+  }
+}, 30000);
+
+wss.on("close", () => {
+  clearInterval(heartbeat);
+});
+
+server.listen(PORT, () => {
+  console.log(`Laser duel server running on port ${PORT}`);
+});
+
+function getRoom(roomId) {
+  let room = rooms.get(roomId);
+  if (!room) {
+    room = { clients: new Map(), state: null };
+    rooms.set(roomId, room);
+  }
+  return room;
+}
+
+function broadcast(roomId, payload) {
+  const room = rooms.get(roomId);
+  if (!room) return;
+  const message = JSON.stringify(payload);
+  for (const client of room.clients.values()) {
+    safeSend(client, message);
+  }
+}
+
+function broadcastPlayers(roomId) {
+  broadcast(roomId, {
+    type: "players",
+    players: getPlayersSnapshot(roomId)
+  });
+}
+
+function getPlayersSnapshot(roomId) {
+  const room = rooms.get(roomId);
+  if (!room) {
+    return { light: false, shadow: false };
+  }
+  return {
+    light: room.clients.has("light"),
+    shadow: room.clients.has("shadow")
+  };
+}
+
+function normaliseRoomId(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase().replace(/[^a-z0-9-_]/gi, "").slice(0, 32);
+}
+
+function send(socket, payload) {
+  safeSend(socket, JSON.stringify(payload));
+}
+
+function safeSend(socket, message) {
+  try {
+    if (socket.readyState === 1) {
+      socket.send(message);
+    }
+  } catch (err) {
+    // игнорируем ошибки отправки
+  }
+}

--- a/style.css
+++ b/style.css
@@ -227,6 +227,154 @@ body.theme-light .button--primary {
   color: #432006;
 }
 
+.connection-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.5rem;
+  background: rgba(10, 14, 18, 0.82);
+  backdrop-filter: blur(8px);
+  z-index: 20;
+  overflow-y: auto;
+}
+
+.connection-card {
+  width: min(100%, 460px);
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 18px;
+  background: var(--bg-panel);
+  box-shadow: inset 0 0 0 1px var(--panel-border-color), 0 30px 60px rgba(0, 0, 0, 0.35);
+}
+
+.connection-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+  text-align: center;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.connection-card__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.connection-field,
+.connection-fieldset {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.connection-field__label,
+.connection-fieldset__legend {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
+.connection-field__input {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border-color);
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--text);
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+}
+
+.connection-field__input:focus {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
+}
+
+.connection-role {
+  display: block;
+  position: relative;
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.connection-role input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+
+.connection-role__content {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.connection-role__glyph {
+  font-size: 1.4rem;
+}
+
+.connection-role__label {
+  font-weight: 600;
+}
+
+.connection-role:has(input:checked) {
+  border-color: var(--accent-dark);
+  background: rgba(98, 146, 255, 0.15);
+}
+
+.connection-role:has(input:focus-visible) {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 3px;
+}
+
+.connection-players {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.connection-players__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.45rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.connection-players__item--occupied {
+  background: rgba(255, 94, 94, 0.12);
+}
+
+.connection-players__item--self {
+  border: 1px solid var(--accent-dark);
+}
+
+.connection-players__status {
+  font-weight: 600;
+}
+
+.connection-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.connection-status {
+  min-height: 1.2rem;
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .board-area {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- add a multiplayer connection overlay so players can choose a side, room, and offline mode
- implement WebSocket-based state synchronisation with turn enforcement in the game client
- provide a Node.js WebSocket relay server and package manifest for hosting the sessions

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6904aa7526788320a47ed19481db8600