### PR TITLE
Revamp hero UI with new factions and legend system

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Лучезарная сечь</title>
+  <title>Mirrors Fight</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="theme-dark">
   <div id="start-screen" class="start-overlay" role="dialog" aria-modal="true" aria-labelledby="start-title">
     <div class="start-card">
-      <h1 id="start-title">Лучезарная сечь</h1>
+      <h1 id="start-title">Mirrors Fight</h1>
       <p class="start-card__intro">Выберите режим, чтобы начать дуэль.</p>
       <div class="start-card__actions">
         <button type="button" id="start-online" class="button button--primary">Онлайн</button>
@@ -35,7 +35,10 @@
       <p class="start-card__intro">Выберите скины и типы для обоих игроков.</p>
       <div class="skin-grid">
         <section class="skin-card" aria-labelledby="offline-light-title">
-          <h3 id="offline-light-title">☼ Дружина Перуна</h3>
+          <h3 id="offline-light-title" class="hero-title">
+            <span class="hero-title__glyph">☼</span>
+            <span class="hero-title__name" data-hero-label="light" data-hero-label-source="pending">Светлый герой</span>
+          </h3>
           <label class="connection-field">
             <span class="connection-field__label">Скин</span>
             <select id="offline-light-skin" class="connection-field__input"></select>
@@ -50,7 +53,10 @@
           </div>
         </section>
         <section class="skin-card" aria-labelledby="offline-shadow-title">
-          <h3 id="offline-shadow-title">☽ Полк Чернобога</h3>
+          <h3 id="offline-shadow-title" class="hero-title">
+            <span class="hero-title__glyph">☽</span>
+            <span class="hero-title__name" data-hero-label="shadow" data-hero-label-source="pending">Теневой герой</span>
+          </h3>
           <label class="connection-field">
             <span class="connection-field__label">Скин</span>
             <select id="offline-shadow-skin" class="connection-field__input"></select>
@@ -94,14 +100,14 @@
           <input type="radio" name="role" value="light" required>
           <span class="connection-role__content">
             <span class="connection-role__glyph">☼</span>
-            <span class="connection-role__label">Дружина Перуна</span>
+            <span class="connection-role__label" data-hero-label="light" data-hero-label-source="pending">Светлый герой</span>
           </span>
         </label>
         <label class="connection-role">
           <input type="radio" name="role" value="shadow" required>
           <span class="connection-role__content">
             <span class="connection-role__glyph">☽</span>
-            <span class="connection-role__label">Полк Чернобога</span>
+            <span class="connection-role__label" data-hero-label="shadow" data-hero-label-source="pending">Теневой герой</span>
           </span>
         </label>
       </fieldset>
@@ -123,11 +129,17 @@
 
       <ul id="connection-players" class="connection-players" aria-live="polite">
         <li class="connection-players__item" data-role="light">
-          <span class="connection-players__name">☼ Дружина Перуна</span>
+          <span class="connection-players__name">
+            <span class="connection-players__glyph">☼</span>
+            <span data-hero-label="light" data-hero-label-source="pending">Светлый герой</span>
+          </span>
           <span class="connection-players__status">свободно</span>
         </li>
         <li class="connection-players__item" data-role="shadow">
-          <span class="connection-players__name">☽ Полк Чернобога</span>
+          <span class="connection-players__name">
+            <span class="connection-players__glyph">☽</span>
+            <span data-hero-label="shadow" data-hero-label-source="pending">Теневой герой</span>
+          </span>
           <span class="connection-players__status">свободно</span>
         </li>
       </ul>
@@ -162,7 +174,7 @@
         </div>
       </div>
       <div class="board-wrapper">
-        <div id="board" class="board" role="grid" aria-label="Поле лучезарной сечи"></div>
+        <div id="board" class="board" role="grid" aria-label="Поле Mirrors Fight"></div>
         <div id="laser-overlay" class="laser-overlay" aria-hidden="true"></div>
       </div>
       <div class="board-actions">
@@ -180,13 +192,7 @@
 
       <section class="panel panel--legend">
         <h2>Легенда орденов</h2>
-        <ul class="legend">
-          <li><span class="legend__glyph legend__glyph--light"><img data-piece-image data-player="light" data-piece="laser" src="pieces/skins/Slavic/Type1/laser.png" alt=""></span> Лучезар (излучает лазер)</li>
-          <li><span class="legend__glyph legend__glyph--light"><img data-piece-image data-player="light" data-piece="volhv" src="pieces/skins/Slavic/Type1/volhv.png" alt=""></span> Волхв (главная цель)</li>
-          <li><span class="legend__glyph legend__glyph--light"><img data-piece-image data-player="light" data-piece="mirror" src="pieces/skins/Slavic/Type1/mirror.png" alt=""></span> Зерцало (одна отражающая грань)</li>
-          <li><span class="legend__glyph legend__glyph--light"><img data-piece-image data-player="light" data-piece="shield" src="pieces/skins/Slavic/Type1/shield.png" alt=""></span> Щитоносец (останавливает луч щитом)</li>
-          <li><span class="legend__glyph legend__glyph--light"><img data-piece-image data-player="light" data-piece="totem" src="pieces/skins/Slavic/Type1/totem.png" alt=""></span> Тотем (двойное зерцало, меняется местами с союзниками, включая диагональ)</li>
-        </ul>
+        <div id="legend-content" class="legend" aria-live="polite"></div>
       </section>
     </aside>
   </main>

--- a/style.css
+++ b/style.css
@@ -149,26 +149,117 @@ body > * {
   color: var(--muted);
 }
 
+.hero-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.hero-title__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 1.1rem;
+}
+
+.hero-title__name {
+  flex: 1;
+}
+
 .legend {
   margin: 0;
-  padding-left: 1rem;
+  padding: 0;
   display: grid;
-  gap: 0.35rem;
+  gap: 1rem;
+}
+
+.legend__group {
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border-color);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.legend__group-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
   font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.legend__group-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 1.1rem;
+}
+
+.legend__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.legend__entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  align-items: center;
 }
 
 .legend__glyph {
-  display: inline-grid;
-  place-items: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  margin-right: 0.35rem;
-  background: rgba(255, 209, 102, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .legend__glyph--light {
-  color: var(--accent-light);
+  background: rgba(255, 209, 102, 0.18);
+}
+
+.legend__glyph--shadow {
+  background: rgba(107, 154, 255, 0.2);
+}
+
+.legend__text {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.legend__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.legend__description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
 }
 
 .button {
@@ -441,6 +532,24 @@ body.theme-light .button--primary {
   background: rgba(255, 255, 255, 0.05);
 }
 
+.connection-players__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.connection-players__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 1rem;
+}
+
 .connection-players__item--occupied {
   background: rgba(255, 94, 94, 0.12);
 }
@@ -643,18 +752,18 @@ body.theme-light .piece {
 }
 
 .endgame {
-  position: absolute;
-  top: 1.25rem;
-  right: 1.25rem;
-  max-width: min(260px, 80%);
+  position: relative;
+  align-self: stretch;
+  width: min(100%, 420px);
+  margin: 0 auto;
   border-radius: 18px;
   padding: 1rem 1.25rem 1.15rem;
-  background: rgba(15, 20, 23, 0.92);
+  background: var(--bg-panel);
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--panel-border-color);
   display: grid;
   gap: 0.75rem;
   text-align: left;
-  z-index: 4;
 }
 
 .endgame h2 {


### PR DESCRIPTION
## Summary
- rename the menus to Mirrors Fight and add hero placeholders throughout the selection screens
- add Lovecraft, Egypt, and coming-soon factions plus dynamic hero metadata with a generated legend panel
- restyle the legend, connection roster, and endgame card so the victory banner no longer obscures the board

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690855e1c9b883208195ab5a1529300e