### PR TITLE
Fix laser desync and refresh beam styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/style.css
+++ b/style.css
@@ -50,6 +50,11 @@ body.theme-dark {
   --muted: #95a4b7;
   --grid-line: rgba(255, 255, 255, 0.08);
   --laser: #ff5e5e;
+  --laser-soft: rgba(255, 138, 120, 0.75);
+  --laser-trail: rgba(255, 118, 103, 0.32);
+  --laser-halo: rgba(255, 214, 191, 0.85);
+  --laser-impact-core: rgba(255, 255, 255, 0.95);
+  --laser-impact-halo: rgba(255, 178, 150, 0.7);
   --page-gradient: radial-gradient(circle at top left, rgba(255, 220, 128, 0.08), transparent 42%),
                    radial-gradient(circle at bottom right, rgba(120, 180, 255, 0.12), transparent 36%),
                    var(--bg);
@@ -87,6 +92,11 @@ body.theme-light {
   --muted: #4b5563;
   --grid-line: rgba(15, 23, 42, 0.08);
   --laser: #d7263d;
+  --laser-soft: rgba(234, 96, 112, 0.7);
+  --laser-trail: rgba(215, 38, 61, 0.28);
+  --laser-halo: rgba(255, 210, 196, 0.78);
+  --laser-impact-core: rgba(255, 255, 255, 0.95);
+  --laser-impact-halo: rgba(255, 186, 170, 0.65);
   --page-gradient: radial-gradient(circle at top left, rgba(244, 196, 94, 0.35), transparent 46%),
                    radial-gradient(circle at bottom right, rgba(96, 165, 250, 0.24), transparent 42%),
                    var(--bg);
@@ -791,52 +801,68 @@ body.theme-light .board-action {
 
 .laser-overlay__beam {
   position: absolute;
-  height: 1.6%;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.2), var(--laser));
-  box-shadow: 0 0 18px var(--laser), 0 0 36px rgba(255, 94, 94, 0.55);
+  height: 1.1%;
+  background:
+    radial-gradient(120% 150% at 15% 50%, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0) 70%),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.85) 0%, var(--laser-soft) 32%, var(--laser) 58%, var(--laser-trail) 78%, rgba(255, 255, 255, 0) 100%);
   border-radius: 999px;
   transform-origin: 0 50%;
   opacity: 0;
-  animation: laser-trace 0.45s ease forwards;
+  box-shadow:
+    0 0 12px var(--laser-halo),
+    0 0 28px var(--laser),
+    0 0 48px var(--laser-trace-glow);
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 0 4px var(--laser-halo));
+  animation: laser-trace 0.45s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .laser-overlay__impact {
   position: absolute;
-  width: 6%;
+  width: 6.2%;
   aspect-ratio: 1;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, var(--laser) 45%, rgba(255, 94, 94, 0) 70%);
+  background:
+    radial-gradient(circle at center, var(--laser-impact-core) 0%, rgba(255, 255, 255, 0.88) 18%, var(--laser-soft) 42%, var(--laser-trail) 70%, rgba(255, 255, 255, 0));
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 22px rgba(255, 94, 94, 0.6);
-  animation: laser-impact 0.5s ease forwards;
+  box-shadow:
+    0 0 16px var(--laser-halo),
+    0 0 34px var(--laser),
+    0 0 52px var(--laser-trace-glow);
+  mix-blend-mode: screen;
+  animation: laser-impact 0.6s ease-out forwards;
 }
 
 @keyframes laser-trace {
   0% {
     opacity: 0;
-    filter: blur(4px);
+    filter: blur(4px) saturate(120%);
   }
-  40% {
-    opacity: 0.9;
-    filter: blur(0.8px);
+  35% {
+    opacity: 0.98;
+    filter: blur(0.6px) saturate(150%);
+  }
+  70% {
+    opacity: 0.82;
+    filter: blur(1px) saturate(120%);
   }
   100% {
-    opacity: 0.75;
-    filter: blur(1.2px);
+    opacity: 0.7;
+    filter: blur(1.3px) saturate(110%);
   }
 }
 
 @keyframes laser-impact {
   0% {
-    transform: translate(-50%, -50%) scale(0.3);
+    transform: translate(-50%, -50%) scale(0.4);
     opacity: 0;
   }
-  50% {
+  45% {
     opacity: 1;
   }
   100% {
-    transform: translate(-50%, -50%) scale(1);
-    opacity: 0.6;
+    transform: translate(-50%, -50%) scale(1.18);
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a pure laser tracing routine and reuse it to resolve damage without mutating shared state
- compute a fallback laser result when syncing remote state so spectators always see the beam
- refresh the laser overlay styling with softer gradients and theme-aware glow variables
- ignore the local node_modules directory

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69085e25f10c83208cac6f9990b32f4d