### PR TITLE
Add move highlight effect and layout selection controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
     <form id="offline-form" class="start-card start-card--wide" autocomplete="off">
       <h2 id="offline-title">Офлайн игра</h2>
       <p class="start-card__intro">Выберите скины и типы для обоих игроков.</p>
+      <label class="connection-field">
+        <span class="connection-field__label">Стартовая позиция</span>
+        <select id="offline-layout" class="connection-field__input"></select>
+      </label>
       <div class="skin-grid">
         <section class="skin-card" aria-labelledby="offline-light-title">
           <h3 id="offline-light-title">☼ Первый Игрок</h3>
@@ -78,10 +82,7 @@
       <h1 id="connection-title" class="connection-card__title">Сетевая партия</h1>
       <p class="connection-card__intro">Укажите комнату и сторону. Второй игрок должен выбрать другой тип скина.</p>
 
-      <label class="connection-field">
-        <span class="connection-field__label">Адрес сервера</span>
-        <input id="server-url" name="server" type="text" class="connection-field__input" required value="wss://mazepark-1.onrender.com" spellcheck="false">
-      </label>
+      <input id="server-url" name="server" type="hidden" value="wss://mazepark-1.onrender.com" spellcheck="false">
 
       <label class="connection-field">
         <span class="connection-field__label">Комната</span>
@@ -105,6 +106,11 @@
           </span>
         </label>
       </fieldset>
+
+      <label class="connection-field">
+        <span class="connection-field__label">Стартовая позиция</span>
+        <select id="online-layout" class="connection-field__input"></select>
+      </label>
 
       <label class="connection-field">
         <span class="connection-field__label">Скин</span>

--- a/style.css
+++ b/style.css
@@ -551,6 +551,13 @@ body.theme-light .connection-warning {
   outline-offset: -3px;
 }
 
+.cell--recent {
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 214, 102, 0.7),
+    inset 0 0 18px rgba(255, 214, 102, 0.35);
+  background-image: linear-gradient(135deg, rgba(255, 214, 102, 0.18), transparent 60%);
+}
+
 .cell--option::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- highlight the previous move's origin and destination squares so players can track piece movement
- add selectable starting layout options to both offline and online setup flows while keeping current placement as default
- hide the manual server address field and connect to the configured endpoint automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dcc990fa083208197f42aaf13534f)