### PR TITLE
Update legacy layout and add logo placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 <body class="theme-dark">
   <div id="start-screen" class="start-overlay" role="dialog" aria-modal="true" aria-labelledby="start-title">
     <div class="start-card">
-      <h1 id="start-title">Зеркальная Битва</h1>
+      <h1 id="start-title" class="start-card__logo">
+        <img src="logo.png" alt="Зеркальная Битва">
+      </h1>
       <p class="start-card__intro">Выберите режим, чтобы начать дуэль.</p>
       <div class="start-card__actions">
         <button type="button" id="start-online" class="button button--primary">Онлайн</button>

--- a/script.js
+++ b/script.js
@@ -13,12 +13,25 @@ const BASE_LAYOUT = [
   ["П", "П", "1З2", "1Щ2", "В2", "2Щ2", "П", "П", "П", "Л2"]
 ];
 
+const MODERN_LAYOUT = BASE_LAYOUT.map((row) => row.map(() => "П"));
+
+const LEGACY_LAYOUT = [
+  ["Л1", "П", "П", "П", "1З1", "В1", "2З1", "П", "П", "П"],
+  ["П", "П", "П", "П", "П", "1Щ1", "П", "П", "П", "П"],
+  ["3З1", "П", "П", "П", "4З1", "2Щ1", "1Т1", "П", "П", "П"],
+  ["5З1", "П", "2Т1", "П", "1З2", "П", "2З2", "П", "П", "П"],
+  ["П", "П", "П", "6З1", "П", "7З1", "П", "1Т2", "П", "3З2"],
+  ["П", "П", "П", "2Т2", "1Щ2", "4З2", "П", "П", "П", "5З2"],
+  ["П", "П", "П", "П", "В2", "П", "П", "П", "П", "П"],
+  ["П", "П", "П", "6З2", "2Щ2", "7З2", "П", "П", "П", "Л2"]
+];
+
 const STARTING_LAYOUT_ORDER = ["basic", "modern", "legacy"];
 
 const STARTING_LAYOUTS = {
   basic: { label: "Базовая", tokens: BASE_LAYOUT },
-  modern: { label: "Модерн", tokens: duplicateLayout(BASE_LAYOUT) },
-  legacy: { label: "Легаси", tokens: duplicateLayout(BASE_LAYOUT) }
+  modern: { label: "Модерн", tokens: MODERN_LAYOUT },
+  legacy: { label: "Легаси", tokens: LEGACY_LAYOUT }
 };
 
 const DEFAULT_LAYOUT_KEY = "basic";

--- a/style.css
+++ b/style.css
@@ -279,6 +279,19 @@ body.theme-light .button--primary {
   margin: 0;
 }
 
+.start-card__logo {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.start-card__logo img {
+  max-width: clamp(180px, 40vw, 260px);
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
 .start-card--wide {
   width: min(760px, 95vw);
   text-align: left;


### PR DESCRIPTION
## Summary
- align the legacy starting layout with the provided legacy board arrangement and keep the modern layout empty for future updates
- replace the start screen heading text with a logo image placeholder so the logo asset can be added later
- add styling for the logo placeholder to display the forthcoming image nicely within the start card

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4f2c9afc83209f9253398600bdef)