### PR TITLE
Enforce unique skin selection per player

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
   <div id="connection-overlay" class="connection-overlay" role="dialog" aria-modal="true" aria-labelledby="connection-title" hidden>
     <form id="connection-form" class="connection-card" autocomplete="off">
       <h1 id="connection-title" class="connection-card__title">Сетевая партия</h1>
-      <p class="connection-card__intro">Укажите комнату и сторону. Второй игрок должен выбрать другой тип скина.</p>
+      <p class="connection-card__intro">Укажите комнату и сторону. Второй игрок должен выбрать другой скин.</p>
 
       <input id="server-url" name="server" type="hidden" value="wss://mazepark-1.onrender.com" spellcheck="false">
 


### PR DESCRIPTION
## Summary
- prevent both players from selecting the same skin while keeping type choices independent
- disable taken skin options and refresh warnings across offline and online skin selectors
- update the multiplayer overlay copy to mention skin conflicts instead of type conflicts

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69103f13a5d08320b5537bc2ea1506b8)