### PR TITLE
Improve destruction audio handling and Japan skin effects

### DIFF
--- a/pieces/skins/Japan/config.json
+++ b/pieces/skins/Japan/config.json
@@ -1,0 +1,28 @@
+{
+  "Type1": {
+    "laser": {
+      "coreColor": "#6fbf5b",
+      "beamGradient": "linear-gradient(90deg, rgba(12, 28, 16, 0.92) 0%, rgba(57, 112, 64, 0.78) 24%, rgba(170, 231, 159, 0.98) 52%, rgba(95, 168, 92, 0.78) 78%, rgba(6, 18, 9, 0.9) 100%)",
+      "glowColor": "rgba(168, 231, 161, 0.72)",
+      "impactGradient": "radial-gradient(circle, rgba(222, 255, 214, 0.98) 0%, rgba(146, 214, 121, 0.84) 40%, rgba(54, 110, 48, 0.58) 68%, rgba(6, 14, 7, 0.88) 100%)",
+      "impactShadow": "rgba(122, 196, 108, 0.75)"
+    },
+    "animations": {
+      "ownDestructionClass": "piece-effect--japan-own",
+      "enemyDestructionClass": "piece-effect--japan-enemy"
+    }
+  },
+  "Type2": {
+    "laser": {
+      "coreColor": "#5aa54a",
+      "beamGradient": "linear-gradient(90deg, rgba(10, 22, 14, 0.92) 0%, rgba(46, 96, 56, 0.82) 26%, rgba(162, 226, 152, 0.98) 50%, rgba(82, 156, 84, 0.82) 76%, rgba(4, 14, 7, 0.92) 100%)",
+      "glowColor": "rgba(154, 220, 144, 0.76)",
+      "impactGradient": "radial-gradient(circle, rgba(216, 255, 208, 0.98) 0%, rgba(132, 200, 116, 0.85) 42%, rgba(44, 94, 52, 0.58) 68%, rgba(5, 12, 7, 0.9) 100%)",
+      "impactShadow": "rgba(110, 182, 102, 0.78)"
+    },
+    "animations": {
+      "ownDestructionClass": "piece-effect--japan-own",
+      "enemyDestructionClass": "piece-effect--japan-enemy"
+    }
+  }
+}

--- a/pieces/skins/premium/config.json
+++ b/pieces/skins/premium/config.json
@@ -1,11 +1,11 @@
 {
   "Type1": {
     "laser": {
-      "coreColor": "#d4af37",
-      "beamGradient": "linear-gradient(90deg, rgba(0, 0, 0, 0.85) 0%, rgba(36, 24, 0, 0.45) 36%, rgba(212, 175, 55, 0.95) 100%)",
-      "glowColor": "rgba(212, 175, 55, 0.65)",
-      "impactGradient": "radial-gradient(circle, rgba(250, 236, 179, 0.95) 0%, rgba(212, 175, 55, 0.8) 48%, rgba(0, 0, 0, 0.75) 78%)",
-      "impactShadow": "rgba(212, 175, 55, 0.7)"
+      "coreColor": "#f7e3a1",
+      "beamGradient": "linear-gradient(90deg, rgba(32, 18, 0, 0.92) 0%, rgba(112, 78, 9, 0.68) 22%, rgba(255, 236, 179, 0.98) 50%, rgba(212, 175, 55, 0.82) 78%, rgba(24, 14, 0, 0.9) 100%)",
+      "glowColor": "rgba(255, 226, 149, 0.78)",
+      "impactGradient": "radial-gradient(circle, rgba(255, 249, 224, 0.98) 0%, rgba(255, 221, 149, 0.85) 38%, rgba(214, 166, 72, 0.55) 62%, rgba(42, 22, 0, 0.88) 100%)",
+      "impactShadow": "rgba(255, 209, 110, 0.78)"
     },
     "animations": {
       "ownDestructionClass": "piece-effect--premium-own",
@@ -19,11 +19,11 @@
   },
   "Type2": {
     "laser": {
-      "coreColor": "#d4af37",
-      "beamGradient": "linear-gradient(90deg, rgba(0, 0, 0, 0.85) 0%, rgba(36, 24, 0, 0.45) 36%, rgba(212, 175, 55, 0.95) 100%)",
-      "glowColor": "rgba(212, 175, 55, 0.65)",
-      "impactGradient": "radial-gradient(circle, rgba(250, 236, 179, 0.95) 0%, rgba(212, 175, 55, 0.8) 48%, rgba(0, 0, 0, 0.75) 78%)",
-      "impactShadow": "rgba(212, 175, 55, 0.7)"
+      "coreColor": "#f4d87e",
+      "beamGradient": "linear-gradient(90deg, rgba(24, 12, 0, 0.9) 0%, rgba(143, 97, 20, 0.7) 24%, rgba(255, 237, 196, 0.98) 48%, rgba(218, 180, 72, 0.85) 74%, rgba(30, 16, 0, 0.9) 100%)",
+      "glowColor": "rgba(255, 216, 138, 0.82)",
+      "impactGradient": "radial-gradient(circle, rgba(255, 244, 209, 0.98) 0%, rgba(244, 201, 104, 0.82) 42%, rgba(180, 116, 28, 0.55) 65%, rgba(32, 16, 0, 0.88) 100%)",
+      "impactShadow": "rgba(248, 195, 102, 0.82)"
     },
     "animations": {
       "ownDestructionClass": "piece-effect--premium-own",

--- a/script.js
+++ b/script.js
@@ -249,6 +249,7 @@ const SKINS = {
   Japan: {
     label: "Япония",
     preview: "pieces/skins/Japan/Type1/preview.png",
+    configPath: "pieces/skins/Japan/config.json",
     types: {
       Type1: { label: "Гейша", preview: "pieces/skins/Japan/Type1/volhv.png" },
       Type2: { label: "Сëгун", preview: "pieces/skins/Japan/Type2/volhv.png" }
@@ -328,6 +329,7 @@ let currentTheme = "dark";
 let lastStatusMessage = "";
 let lastLaserResult = null;
 let lastLaserEffectSignature = null;
+let lastLaserEffectTimestamp = 0;
 let lastMove = null;
 let skinSelection = cloneSkinSelection(DEFAULT_SKIN_SELECTION);
 let pendingSkins = cloneSkinSelection(DEFAULT_SKIN_SELECTION);
@@ -1973,6 +1975,7 @@ function clearLaserPath({ preserveState = false } = {}) {
   if (!preserveState) {
     lastLaserResult = null;
     lastLaserEffectSignature = null;
+    lastLaserEffectTimestamp = 0;
     resetLaserOverlayTheme();
   }
 }
@@ -2138,11 +2141,13 @@ function handleLaserImpact(result) {
     return;
   }
   const signature = computeLaserSignature(result);
-  if (signature && signature === lastLaserEffectSignature) {
+  const now = Date.now();
+  if (signature && signature === lastLaserEffectSignature && now - lastLaserEffectTimestamp < 250) {
     return;
   }
   if (signature) {
     lastLaserEffectSignature = signature;
+    lastLaserEffectTimestamp = now;
   }
   const attacker = result.player || null;
   const attackerSelection = result.skin && result.skin.skin

--- a/style.css
+++ b/style.css
@@ -875,6 +875,47 @@ body.theme-light .board-action {
   animation: premium-enemy-burst 0.72s cubic-bezier(0.32, 0.05, 0.36, 1) forwards;
 }
 
+.piece-effect--japan-own {
+  width: 11.5%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(182, 235, 171, 0.95) 0%, rgba(98, 168, 92, 0.72) 52%, rgba(12, 36, 16, 0.88) 100%);
+  box-shadow:
+    0 0 22px rgba(148, 214, 133, 0.55),
+    0 0 48px rgba(42, 102, 52, 0.35);
+  mix-blend-mode: screen;
+  animation: japan-own-pulse 0.75s ease-out forwards;
+}
+
+.piece-effect--japan-enemy {
+  width: 16%;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0) 40%, rgba(234, 255, 226, 0.95) 47%, rgba(108, 196, 97, 0.95) 50%, rgba(234, 255, 226, 0.95) 53%, rgba(255, 255, 255, 0) 60%);
+  filter: drop-shadow(0 0 22px rgba(132, 214, 122, 0.65));
+  animation: japan-slice-line 0.45s ease-out forwards;
+}
+
+.piece-effect--japan-enemy::before,
+.piece-effect--japan-enemy::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 58%;
+  height: 74%;
+  background: radial-gradient(circle at 50% 40%, rgba(242, 255, 234, 0.95) 0%, rgba(158, 222, 146, 0.78) 55%, rgba(44, 94, 50, 0.78) 100%);
+  border-radius: 28% 38% 48% 32%;
+  opacity: 0;
+  transform-origin: center;
+  box-shadow: 0 0 18px rgba(136, 214, 122, 0.45);
+}
+
+.piece-effect--japan-enemy::before {
+  animation: japan-slice-left 0.62s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+}
+
+.piece-effect--japan-enemy::after {
+  animation: japan-slice-right 0.62s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+}
+
 @keyframes premium-own-collapse {
   0% {
     opacity: 0.95;
@@ -908,6 +949,72 @@ body.theme-light .board-action {
     opacity: 0;
     transform: translate(-50%, -50%) scale(1.48);
     filter: blur(6px) brightness(0.65);
+  }
+}
+
+@keyframes japan-own-pulse {
+  0% {
+    opacity: 0.95;
+    transform: translate(-50%, -50%) scale(0.7);
+    filter: blur(1px);
+  }
+  45% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.05);
+    filter: blur(1.5px);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.45);
+    filter: blur(4px);
+  }
+}
+
+@keyframes japan-slice-line {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.65) rotate(18deg);
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.05) rotate(18deg);
+  }
+}
+
+@keyframes japan-slice-left {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.85) rotate(-6deg);
+  }
+  20% {
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-82%, -58%) scale(0.85) rotate(-18deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-108%, -78%) scale(0.75) rotate(-24deg);
+  }
+}
+
+@keyframes japan-slice-right {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.85) rotate(6deg);
+  }
+  20% {
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-18%, -42%) scale(0.85) rotate(18deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(8%, -70%) scale(0.75) rotate(26deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure destroy sound effects trigger reliably by relaxing the signature cache and resetting it when the beam clears
- refresh the premium skin laser palette for a warmer, more natural beam and impact
- add Japan skin laser configuration plus stylised matcha beam and katana-inspired destruction animation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105f79dfb0832092684ea091b6a30c)