### PR TITLE
Add history persistence, premium lighting, and ratings

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,12 @@
 
       <p id="connection-status" class="connection-status" role="status"></p>
 
+      <section class="connection-rating" aria-live="polite">
+        <h2 class="connection-rating__title">Глобальный рейтинг</h2>
+        <p id="connection-player-rating" class="connection-rating__value rating__value">Рейтинг недоступен.</p>
+        <ol id="connection-leaderboard" class="connection-rating__list rating__list" aria-label="Лидеры онлайн режима"></ol>
+      </section>
+
       <div class="connection-actions">
         <button type="submit" id="connect-button" class="button button--primary">Подключиться</button>
         <button type="button" id="online-back" class="button button--ghost">Назад</button>
@@ -192,6 +198,11 @@
         <h2>Фигура</h2>
         <p id="piece-name" class="piece-panel__name">—</p>
         <p id="piece-details" class="piece-panel__details">Коснитесь своей фигуры, чтобы узнать её свойства.</p>
+      </section>
+      <section class="panel panel--rating" aria-live="polite">
+        <h2>Рейтинг</h2>
+        <p id="player-rating" class="rating__value">Онлайн-рейтинг недоступен</p>
+        <ol id="leaderboard" class="rating__list" aria-label="Топ игроков"></ol>
       </section>
     </aside>
   </main>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "firebase-admin": "^11.10.1",
     "ws": "^8.14.2"
   }
 }

--- a/pieces/skins/Japan/config.json
+++ b/pieces/skins/Japan/config.json
@@ -25,6 +25,20 @@
         "offset": { "x": 0, "y": 0 },
         "scale": 1.6
       }
+    },
+    "board": {
+      "theme": "japan-garden",
+      "background": "linear-gradient(135deg, rgba(9, 21, 12, 0.92) 0%, rgba(34, 73, 40, 0.82) 48%, rgba(14, 31, 18, 0.95) 100%)",
+      "grid": "rgba(170, 231, 159, 0.18)",
+      "light": "rgba(214, 238, 210, 0.95)",
+      "dark": "rgba(48, 85, 54, 0.92)",
+      "overlay": {
+        "primary": "rgba(156, 214, 144, 0.32)",
+        "secondary": "rgba(50, 95, 54, 0.35)",
+        "opacity": 0.4,
+        "blend": "screen"
+      },
+      "frame": "linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(186, 228, 177, 0.4) 50%, rgba(10, 24, 12, 0.7) 100%)"
     }
   },
   "Type2": {
@@ -53,6 +67,20 @@
         "offset": { "x": 0, "y": 0 },
         "scale": 1.6
       }
+    },
+    "board": {
+      "theme": "japan-imperial",
+      "background": "linear-gradient(135deg, rgba(8, 18, 12, 0.92) 0%, rgba(40, 86, 48, 0.86) 50%, rgba(10, 22, 13, 0.95) 100%)",
+      "grid": "rgba(162, 226, 152, 0.2)",
+      "light": "rgba(225, 245, 220, 0.95)",
+      "dark": "rgba(44, 82, 50, 0.92)",
+      "overlay": {
+        "primary": "rgba(148, 210, 138, 0.38)",
+        "secondary": "rgba(36, 74, 40, 0.32)",
+        "opacity": 0.42,
+        "blend": "screen"
+      },
+      "frame": "linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, rgba(166, 216, 156, 0.45) 52%, rgba(6, 16, 9, 0.7) 100%)"
     }
   }
 }

--- a/pieces/skins/premium/config.json
+++ b/pieces/skins/premium/config.json
@@ -26,6 +26,18 @@
         "scale": 1.8
       }
     },
+    "heroLighting": {
+      "volhv": {
+        "haloGradient": "radial-gradient(circle, rgba(255, 240, 206, 0.95) 0%, rgba(255, 226, 158, 0.7) 38%, rgba(106, 82, 24, 0.45) 62%, rgba(24, 14, 0, 0) 100%)",
+        "innerGlow": "rgba(255, 225, 149, 0.75)",
+        "outerGlow": "rgba(212, 175, 55, 0.45)",
+        "beamColor": "rgba(255, 235, 190, 0.55)",
+        "pulse": {
+          "from": "rgba(255, 226, 149, 0.35)",
+          "to": "rgba(255, 244, 214, 0.85)"
+        }
+      }
+    },
     "sounds": {
       "move": "pieces/skins/premium/audio/move.wav",
       "destroyEnemy": "pieces/skins/premium/audio/destroy-enemy.wav",
@@ -57,6 +69,18 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      }
+    },
+    "heroLighting": {
+      "volhv": {
+        "haloGradient": "radial-gradient(circle, rgba(255, 236, 194, 0.95) 0%, rgba(248, 205, 124, 0.7) 36%, rgba(94, 70, 18, 0.45) 60%, rgba(26, 16, 0, 0) 100%)",
+        "innerGlow": "rgba(255, 220, 149, 0.78)",
+        "outerGlow": "rgba(218, 180, 72, 0.42)",
+        "beamColor": "rgba(255, 240, 210, 0.6)",
+        "pulse": {
+          "from": "rgba(255, 220, 149, 0.32)",
+          "to": "rgba(255, 240, 206, 0.88)"
+        }
       }
     },
     "sounds": {

--- a/server.js
+++ b/server.js
@@ -1,11 +1,25 @@
 const http = require("http");
 const { WebSocketServer } = require("ws");
+const fs = require("fs");
+const path = require("path");
 
 const PORT = Number(process.env.PORT || 8787);
 
-const rooms = new Map();
+const DATA_DIR = path.join(__dirname, "data");
+const MATCHES_PATH = path.join(DATA_DIR, "match-history.json");
+const RATINGS_PATH = path.join(DATA_DIR, "ratings.json");
+const DEFAULT_RATING = 1200;
+const HISTORY_THRESHOLD = 6;
+const MAX_HISTORY_LENGTH = 256;
+const K_FACTOR = 32;
 
-const server = http.createServer();
+const rooms = new Map();
+ensureDataStorage();
+
+let matchHistory = loadJson(MATCHES_PATH, []);
+let globalRatings = loadJson(RATINGS_PATH, {});
+
+const server = http.createServer(handleHttpRequest);
 const wss = new WebSocketServer({ server });
 
 wss.on("connection", (socket) => {
@@ -40,6 +54,12 @@ wss.on("connection", (socket) => {
 
     if (payload.type === "state") {
       handleStateUpdate(membership, payload);
+      return;
+    }
+
+    if (payload.type === "history") {
+      handleHistoryMessage(membership, payload);
+      return;
     }
   });
 
@@ -50,6 +70,9 @@ wss.on("connection", (socket) => {
     const current = room.clients.get(membership.role);
     if (current === socket) {
       room.clients.delete(membership.role);
+      if (room.playerIds && membership.role) {
+        room.playerIds[membership.role] = null;
+      }
       broadcastPlayers(membership.roomId);
       if (room.clients.size === 0) {
         rooms.delete(membership.roomId);
@@ -84,7 +107,12 @@ wss.on("connection", (socket) => {
     }
 
     room.clients.set(role, ws);
-    membership = { roomId, role };
+    const playerId = sanitisePlayerId(payload.playerId);
+    if (!room.playerIds) {
+      room.playerIds = { light: null, shadow: null };
+    }
+    room.playerIds[role] = playerId;
+    membership = { roomId, role, playerId };
 
     const desiredSkin = sanitiseSkinEntry({ skin: payload.skin, type: payload.skinType });
     room.skins = mergeSkins(room.skins, { [role]: desiredSkin });
@@ -100,10 +128,18 @@ wss.on("connection", (socket) => {
       players: getPlayersSnapshot(roomId),
       state: room.state,
       laser: room.lastLaser,
+      matchId: room.historyMatchId || null,
+      exportedLength: Array.isArray(room.history) ? room.history.length : 0,
+      ratings: buildRatingsPayload(room, playerId),
       message: `Подключено к комнате ${roomId}.`
     });
 
     broadcastPlayers(roomId);
+    for (const [otherRole, clientSocket] of room.clients.entries()) {
+      if (!clientSocket || clientSocket === ws) continue;
+      const ratingsPayload = buildRatingsPayload(room, room.playerIds ? room.playerIds[otherRole] : null);
+      send(clientSocket, { type: "ratings", ratings: ratingsPayload });
+    }
     if (room.state && room.clients.size > 1) {
       const mergedSkins = mergeSkins(room.state.skins || {}, room.skins);
       room.state = { ...room.state, skins: mergedSkins };
@@ -153,6 +189,61 @@ wss.on("connection", (socket) => {
     }
     broadcast(member.roomId, message);
   }
+
+  function handleHistoryMessage(member, payload) {
+    if (!member) return;
+    const room = rooms.get(member.roomId);
+    if (!room || room.clients.get(member.role) !== socket) {
+      return;
+    }
+    const moves = Array.isArray(payload.history) ? payload.history.slice(0, MAX_HISTORY_LENGTH) : [];
+    if (!moves.length) {
+      return;
+    }
+    const sanitisedMoves = moves.map(sanitiseHistoryEntry).filter(Boolean).slice(-MAX_HISTORY_LENGTH);
+    if (!sanitisedMoves.length) {
+      return;
+    }
+    const incomingMatchId = sanitiseMatchId(payload.matchId);
+    const matchId = incomingMatchId || room.historyMatchId || generateMatchId();
+    room.history = sanitisedMoves;
+    room.historyMatchId = matchId;
+
+    const destroyedHero = sanitiseRole(payload.destroyedHero);
+    const winnerRole = sanitiseRole(payload.winner);
+    const metadata = {
+      final: Boolean(payload.final),
+      destroyedHero,
+      winner: winnerRole,
+      layout: sanitiseLayoutKey(payload.layout),
+      skins: sanitiseSkins(payload.skins)
+    };
+
+    if (metadata.final && winnerRole && destroyedHero) {
+      applyMatchResultRatings(room, winnerRole);
+      saveRatings();
+    }
+
+    if (metadata.final || sanitisedMoves.length > HISTORY_THRESHOLD) {
+      persistMatchRecord(member.roomId, matchId, room, sanitisedMoves, metadata);
+    }
+
+    const ackRatings = buildRatingsPayload(room, room.playerIds[member.role]);
+    send(socket, {
+      type: "history-ack",
+      matchId,
+      exportedLength: sanitisedMoves.length,
+      ratings: ackRatings
+    });
+
+    if (metadata.final && winnerRole && destroyedHero) {
+      for (const [role, clientSocket] of room.clients.entries()) {
+        if (!clientSocket || clientSocket === socket) continue;
+        const ratingsPayload = buildRatingsPayload(room, room.playerIds[role]);
+        send(clientSocket, { type: "ratings", ratings: ratingsPayload });
+      }
+    }
+  }
 });
 
 const heartbeat = setInterval(() => {
@@ -174,10 +265,309 @@ server.listen(PORT, () => {
   console.log(`Laser duel server running on port ${PORT}`);
 });
 
+function sanitisePlayerId(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 64);
+}
+
+function sanitiseRole(value) {
+  return value === "light" || value === "shadow" ? value : null;
+}
+
+function sanitiseMatchId(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 48);
+}
+
+function generateMatchId() {
+  return `match-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitiseLayoutKey(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 32);
+}
+
+function sanitiseNotation(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 4);
+}
+
+const ALLOWED_DIRECTIONS = new Set(["↑", "↗", "→", "↘", "↓", "↙", "←", "↖"]);
+
+function sanitiseDirection(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return ALLOWED_DIRECTIONS.has(trimmed) ? trimmed : null;
+}
+
+function sanitisePieceType(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 24);
+}
+
+function sanitiseAction(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 24);
+}
+
+function sanitiseRotation(value) {
+  if (!value || typeof value !== "object") return null;
+  const direction = typeof value.direction === "string" ? value.direction.trim() : null;
+  const delta = Number(value.degrees);
+  const before = typeof value.before === "string" ? value.before.trim() : null;
+  const after = typeof value.after === "string" ? value.after.trim() : null;
+  return {
+    direction: direction && direction.length <= 2 ? direction : null,
+    degrees: Number.isFinite(delta) ? delta : null,
+    before: before && before.length <= 2 ? before : null,
+    after: after && after.length <= 2 ? after : null
+  };
+}
+
+function sanitiseCapture(value) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    pieceType: sanitisePieceType(value.pieceType),
+    player: sanitiseRole(value.player),
+    at: sanitiseNotation(value.at)
+  };
+}
+
+function sanitiseHistoryEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+  const order = Number(entry.order);
+  const turn = Number(entry.turn);
+  return {
+    order: Number.isFinite(order) ? order : null,
+    turn: Number.isFinite(turn) ? turn : null,
+    player: sanitiseRole(entry.player),
+    pieceType: sanitisePieceType(entry.pieceType),
+    action: sanitiseAction(entry.action),
+    from: sanitiseNotation(entry.from),
+    to: sanitiseNotation(entry.to),
+    direction: sanitiseDirection(entry.direction),
+    rotation: sanitiseRotation(entry.rotation),
+    capture: sanitiseCapture(entry.capture),
+    destroyedHero: sanitiseRole(entry.destroyedHero),
+    swapWith: sanitisePieceType(entry.swapWith),
+    swapWithPlayer: sanitiseRole(entry.swapWithPlayer)
+  };
+}
+
+function sanitiseSkins(value) {
+  const result = { light: null, shadow: null };
+  if (!value || typeof value !== "object") {
+    return result;
+  }
+  for (const role of ["light", "shadow"]) {
+    result[role] = sanitiseSkinEntry(value[role]);
+  }
+  return result;
+}
+
+function persistMatchRecord(roomId, matchId, room, moves, metadata = {}) {
+  if (!matchId) return;
+  const timestamp = new Date().toISOString();
+  let record = matchHistory.find((item) => item.matchId === matchId);
+  if (!record) {
+    record = { matchId, createdAt: timestamp };
+    matchHistory.push(record);
+  }
+  record.roomId = roomId;
+  record.updatedAt = timestamp;
+  record.status = metadata.final ? "completed" : "in-progress";
+  record.moves = moves;
+  record.layout = metadata.layout || null;
+  record.skins = metadata.skins || { light: null, shadow: null };
+  record.players = {
+    light: room.playerIds && room.playerIds.light ? { id: room.playerIds.light, rating: getRating(room.playerIds.light) } : null,
+    shadow: room.playerIds && room.playerIds.shadow ? { id: room.playerIds.shadow, rating: getRating(room.playerIds.shadow) } : null
+  };
+  if (metadata.final) {
+    record.outcome = {
+      winner: metadata.winner,
+      destroyedHero: metadata.destroyedHero
+    };
+    record.completedAt = record.completedAt || timestamp;
+  }
+  if (matchHistory.length > 500) {
+    matchHistory = matchHistory.slice(matchHistory.length - 500);
+  }
+  saveMatchHistory();
+}
+
+function applyMatchResultRatings(room, winnerRole) {
+  const winnerId = room.playerIds ? room.playerIds[winnerRole] : null;
+  const loserRole = winnerRole === "light" ? "shadow" : "light";
+  const loserId = room.playerIds ? room.playerIds[loserRole] : null;
+  if (!winnerId || !loserId) {
+    return;
+  }
+  const winnerEntry = getRatingEntry(winnerId);
+  const loserEntry = getRatingEntry(loserId);
+  const expectedWinner = 1 / (1 + Math.pow(10, (loserEntry.rating - winnerEntry.rating) / 400));
+  const expectedLoser = 1 - expectedWinner;
+  winnerEntry.rating = Math.round(winnerEntry.rating + K_FACTOR * (1 - expectedWinner));
+  loserEntry.rating = Math.round(loserEntry.rating + K_FACTOR * (0 - expectedLoser));
+  winnerEntry.games += 1;
+  loserEntry.games += 1;
+  globalRatings[winnerId] = winnerEntry;
+  globalRatings[loserId] = loserEntry;
+}
+
+function getRatingEntry(id) {
+  if (!id) {
+    return { rating: DEFAULT_RATING, games: 0 };
+  }
+  const existing = globalRatings[id];
+  if (existing && Number.isFinite(existing.rating)) {
+    return { rating: Number(existing.rating), games: Number(existing.games) || 0 };
+  }
+  return { rating: DEFAULT_RATING, games: 0 };
+}
+
+function getRating(id) {
+  return getRatingEntry(id).rating;
+}
+
+function getLeaderboard(limit = 10) {
+  return Object.entries(globalRatings)
+    .filter(([, entry]) => entry && Number.isFinite(entry.rating))
+    .map(([id, entry]) => ({ id, rating: Math.round(entry.rating) }))
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, limit);
+}
+
+function buildRatingsPayload(room, playerId) {
+  const payload = {
+    leaderboard: getLeaderboard(10),
+    players: {
+      light: room.playerIds && room.playerIds.light ? { id: room.playerIds.light, rating: getRating(room.playerIds.light) } : null,
+      shadow: room.playerIds && room.playerIds.shadow ? { id: room.playerIds.shadow, rating: getRating(room.playerIds.shadow) } : null
+    }
+  };
+  if (playerId) {
+    payload.player = { id: playerId, rating: getRating(playerId) };
+  } else {
+    payload.player = null;
+  }
+  return payload;
+}
+
+function saveRatings() {
+  saveJson(RATINGS_PATH, globalRatings);
+}
+
+function saveMatchHistory() {
+  saveJson(MATCHES_PATH, matchHistory);
+}
+
+function ensureDataStorage() {
+  try {
+    if (!fs.existsSync(DATA_DIR)) {
+      fs.mkdirSync(DATA_DIR, { recursive: true });
+    }
+    if (!fs.existsSync(MATCHES_PATH)) {
+      fs.writeFileSync(MATCHES_PATH, "[]", "utf8");
+    }
+    if (!fs.existsSync(RATINGS_PATH)) {
+      fs.writeFileSync(RATINGS_PATH, "{}", "utf8");
+    }
+  } catch (err) {
+    console.error("Failed to initialise data storage", err);
+  }
+}
+
+function loadJson(filePath, fallback) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (err) {
+    return fallback;
+  }
+}
+
+function saveJson(filePath, value) {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+  } catch (err) {
+    console.error("Failed to write", filePath, err);
+  }
+}
+
+function handleHttpRequest(req, res) {
+  try {
+    if (req.method === "OPTIONS") {
+      setCorsHeaders(res);
+      res.writeHead(204).end();
+      return;
+    }
+    if (req.method === "GET") {
+      const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+      if (url.pathname === "/ratings") {
+        setCorsHeaders(res);
+        const playerId = sanitisePlayerId(url.searchParams.get("playerId"));
+        const payload = {
+          player: playerId ? { id: playerId, rating: getRating(playerId) } : null,
+          leaderboard: getLeaderboard(20)
+        };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(payload));
+        return;
+      }
+      if (url.pathname === "/matches") {
+        setCorsHeaders(res);
+        const limitParam = Number(url.searchParams.get("limit"));
+        const limit = Number.isFinite(limitParam) ? Math.min(Math.max(Math.floor(limitParam), 1), 100) : 20;
+        const matches = matchHistory.slice(-limit);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ matches }));
+        return;
+      }
+    }
+    setCorsHeaders(res);
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  } catch (err) {
+    setCorsHeaders(res);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Server error" }));
+  }
+}
+
+function setCorsHeaders(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+}
+
 function getRoom(roomId) {
   let room = rooms.get(roomId);
   if (!room) {
-    room = { clients: new Map(), state: null, lastLaser: null, skins: { light: null, shadow: null } };
+    room = {
+      clients: new Map(),
+      state: null,
+      lastLaser: null,
+      skins: { light: null, shadow: null },
+      history: [],
+      historyMatchId: null,
+      playerIds: { light: null, shadow: null }
+    };
     rooms.set(roomId, room);
   }
   return room;

--- a/style.css
+++ b/style.css
@@ -696,6 +696,40 @@ body.theme-light .connection-warning {
   color: var(--muted);
 }
 
+.connection-rating {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.connection-rating__title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.connection-rating__value {
+  margin: 0;
+  font-weight: 600;
+}
+
+.connection-rating__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+body.theme-light .connection-rating {
+  background: rgba(15, 23, 42, 0.08);
+}
+
 .board-area {
   position: relative;
   display: flex;
@@ -706,6 +740,28 @@ body.theme-light .connection-warning {
 
 .board-wrapper {
   position: relative;
+  padding: 0;
+}
+
+.board-wrapper::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 24px;
+  background: var(--board-frame-background, transparent);
+  opacity: var(--board-frame-opacity, 0);
+  transition: opacity 0.4s ease;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.board-wrapper[data-board-frame="visible"]::before {
+  opacity: 1;
+}
+
+.board-wrapper > .board {
+  position: relative;
+  z-index: 1;
 }
 
 .board {
@@ -719,8 +775,31 @@ body.theme-light .connection-warning {
   border: 1px solid var(--panel-border-color);
   box-shadow: var(--board-shadow);
   position: relative;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 70%);
+  background: var(--board-theme-background, linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 70%));
   isolation: isolate;
+}
+
+.board::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(
+      to right,
+      transparent calc(100% - 1px),
+      var(--board-theme-grid, transparent) calc(100% - 1px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(100% - 1px),
+      var(--board-theme-grid, transparent) calc(100% - 1px)
+    );
+  background-size: calc(100% / var(--board-columns, 10)) 100%, 100% calc(100% / var(--board-rows, 8));
+  opacity: var(--board-grid-opacity, 0);
+  pointer-events: none;
+  z-index: 0;
+  mix-blend-mode: soft-light;
+  transition: opacity 0.4s ease;
 }
 
 .board::after {
@@ -734,7 +813,7 @@ body.theme-light .connection-warning {
   mix-blend-mode: var(--board-overlay-blend);
   pointer-events: none;
   transition: opacity 0.4s ease;
-  z-index: 0;
+  z-index: 1;
 }
 
 .cell {
@@ -841,6 +920,88 @@ body.theme-light .piece {
   transition: transform 0.2s ease;
   transform-origin: center;
   object-fit: contain;
+  position: relative;
+  z-index: 1;
+}
+
+.piece--hero-premium {
+  filter: drop-shadow(0 0 16px rgba(255, 226, 149, 0.45));
+}
+
+.piece-lighting {
+  position: absolute;
+  inset: -18%;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  mix-blend-mode: screen;
+}
+
+.piece-lighting--halo {
+  background: var(
+    --hero-halo,
+    radial-gradient(circle, rgba(255, 240, 206, 0.9) 0%, rgba(212, 175, 55, 0.6) 45%, rgba(24, 14, 0, 0) 100%)
+  );
+  box-shadow:
+    0 0 28px var(--hero-outer-glow, rgba(212, 175, 55, 0.45)),
+    0 0 42px var(--hero-inner-glow, rgba(255, 225, 149, 0.4));
+  animation: premium-hero-halo 3.2s ease-in-out infinite;
+}
+
+.piece-lighting--halo::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--hero-pulse-from, rgba(255, 226, 149, 0.32)) 0%, transparent 70%);
+  animation: premium-hero-pulse 3.2s ease-in-out infinite;
+}
+
+.piece-lighting--beam {
+  inset: -28% 16%;
+  border-radius: 45% 45% 55% 55% / 55% 55% 40% 40%;
+  background: radial-gradient(circle at 50% 20%, var(--hero-beam, rgba(255, 235, 190, 0.55)) 0%, transparent 70%);
+  filter: blur(6px);
+  opacity: 0.75;
+  animation: premium-hero-beam 4s ease-in-out infinite;
+}
+
+@keyframes premium-hero-halo {
+  0%,
+  100% {
+    transform: scale(0.94);
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+}
+
+@keyframes premium-hero-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.8);
+    background: radial-gradient(circle, var(--hero-pulse-from, rgba(255, 226, 149, 0.32)) 0%, transparent 70%);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scale(1);
+    background: radial-gradient(circle, var(--hero-pulse-to, rgba(255, 244, 214, 0.85)) 0%, transparent 72%);
+  }
+}
+
+@keyframes premium-hero-beam {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scaleY(0.95);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scaleY(1.05);
+  }
 }
 
 .legend__glyph img {
@@ -1005,6 +1166,70 @@ body.theme-light .board-action {
 .panel--piece {
   display: grid;
   gap: 0.5rem;
+}
+
+.panel--rating {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.rating__value {
+  margin: 0;
+  font-weight: 600;
+}
+
+.rating__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.rating__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+.rating__position {
+  font-weight: 700;
+  color: var(--accent-dark);
+}
+
+.rating__name {
+  font-weight: 600;
+}
+
+.rating__score {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.rating__empty {
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+body.theme-light .rating__item {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+body.theme-light .rating__position {
+  color: var(--accent-light);
+}
+
+body.theme-light .rating__empty {
+  background: rgba(15, 23, 42, 0.06);
 }
 
 .piece-panel__name {


### PR DESCRIPTION
## Summary
- persist match histories and global ratings on the server, including new rating endpoints and history acknowledgements
- capture detailed move history and rating updates on the client alongside premium hero lighting and Japan board theming
- expose new rating UI panels and styling, with JSON skin updates powering lighting and board themes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ccb59a6c8320a70539b484973df5)