### PR TITLE
Fix board cell sizing and ensure smooth piece rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@
         </div>
       </div>
       <div class="board-wrapper">
+        <div id="board-atmosphere" class="board-atmosphere" aria-hidden="true"></div>
         <div id="board" class="board" role="grid" aria-label="Поле лучезарной сечи"></div>
         <div id="effects-overlay" class="effects-overlay" aria-hidden="true"></div>
         <div id="laser-overlay" class="laser-overlay" aria-hidden="true"></div>

--- a/pieces/skins/Arnuvo/config.json
+++ b/pieces/skins/Arnuvo/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 2.25
+      },
+      "rotation": {
+        "duration": 320,
+        "easing": "cubic-bezier(0.23, 1, 0.32, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(250, 192, 222, 0.82)",
+        "idleOpacity": 0.45,
+        "activeOpacity": 0.72,
+        "blur": 28,
+        "scale": 1.06
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 2.35
+      },
+      "rotation": {
+        "duration": 320,
+        "easing": "cubic-bezier(0.23, 1, 0.32, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(247, 188, 222, 0.85)",
+        "idleOpacity": 0.46,
+        "activeOpacity": 0.74,
+        "blur": 28,
+        "scale": 1.06
       }
     },
     "sounds": {

--- a/pieces/skins/Egypt/config.json
+++ b/pieces/skins/Egypt/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.7
+      },
+      "rotation": {
+        "duration": 280,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(255, 214, 132, 0.76)",
+        "idleOpacity": 0.44,
+        "activeOpacity": 0.7,
+        "blur": 26,
+        "scale": 1.05
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 280,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(132, 220, 255, 0.76)",
+        "idleOpacity": 0.44,
+        "activeOpacity": 0.7,
+        "blur": 26,
+        "scale": 1.05
       }
     },
     "sounds": {

--- a/pieces/skins/Egypt/config.json
+++ b/pieces/skins/Egypt/config.json
@@ -39,6 +39,26 @@
         "scale": 1.05
       }
     },
+    "environment": {
+      "particles": {
+        "count": 34,
+        "colors": [
+          "rgba(255, 214, 132, 0.42)",
+          "rgba(255, 198, 102, 0.28)",
+          "rgba(244, 236, 192, 0.22)"
+        ],
+        "size": { "min": 0.7, "max": 1.85 },
+        "opacity": { "min": 0.18, "max": 0.4 },
+        "duration": { "min": 13, "max": 26 },
+        "delay": { "min": 0, "max": 18 },
+        "verticalDrift": { "min": 18, "max": 46 },
+        "horizontalDrift": { "min": -6, "max": 6 },
+        "blur": { "min": 0, "max": 5.5 },
+        "scaleStart": { "min": 0.65, "max": 0.92 },
+        "scaleEnd": { "min": 1.05, "max": 1.28 },
+        "startY": { "min": -4, "max": 14 }
+      }
+    },
     "sounds": {
       "move": "pieces/skins/Egypt/audio/type1-move.mp3",
       "destroyEnemy": "pieces/skins/Egypt/audio/type1-destroy.mp3",
@@ -83,6 +103,26 @@
         "activeOpacity": 0.7,
         "blur": 26,
         "scale": 1.05
+      }
+    },
+    "environment": {
+      "particles": {
+        "count": 32,
+        "colors": [
+          "rgba(132, 220, 255, 0.38)",
+          "rgba(102, 186, 240, 0.26)",
+          "rgba(200, 244, 255, 0.24)"
+        ],
+        "size": { "min": 0.68, "max": 1.75 },
+        "opacity": { "min": 0.16, "max": 0.36 },
+        "duration": { "min": 12, "max": 24 },
+        "delay": { "min": 0, "max": 16 },
+        "verticalDrift": { "min": 16, "max": 42 },
+        "horizontalDrift": { "min": -7, "max": 7 },
+        "blur": { "min": 0, "max": 6 },
+        "scaleStart": { "min": 0.62, "max": 0.9 },
+        "scaleEnd": { "min": 1.04, "max": 1.24 },
+        "startY": { "min": -6, "max": 12 }
       }
     },
     "sounds": {

--- a/pieces/skins/Greece/config.json
+++ b/pieces/skins/Greece/config.json
@@ -36,7 +36,32 @@
         "idleOpacity": 0.43,
         "activeOpacity": 0.7,
         "blur": 24,
-        "scale": 1.04
+        "scale": 1.04,
+        "inset": 0.1,
+        "glowRadius": 52,
+        "glowSpread": 10
+      }
+    },
+    "board": {
+      "background": "linear-gradient(135deg, rgba(12, 22, 38, 0.98) 0%, rgba(22, 34, 54, 0.94) 48%, rgba(10, 18, 34, 0.98) 100%)",
+      "wrapper": {
+        "background": "radial-gradient(680px circle at 22% 18%, rgba(156, 210, 255, 0.24) 0%, transparent 64%), radial-gradient(560px circle at 78% 84%, rgba(44, 78, 122, 0.28) 0%, transparent 72%)"
+      },
+      "cell": {
+        "dark": "rgba(14, 26, 44, 0.98)",
+        "light": "rgba(30, 46, 70, 0.96)",
+        "border": "rgba(156, 210, 255, 0.35)",
+        "innerGlow": "rgba(156, 210, 255, 0.18)"
+      },
+      "overlay": {
+        "primary": "rgba(156, 210, 255, 0.36)",
+        "secondary": "rgba(68, 116, 174, 0.28)",
+        "opacity": 0.52,
+        "blendMode": "screen"
+      },
+      "frame": {
+        "border": "1px solid rgba(156, 210, 255, 0.42)",
+        "shadow": "0 36px 78px rgba(6, 14, 30, 0.58)"
       }
     },
     "sounds": {
@@ -82,7 +107,32 @@
         "idleOpacity": 0.43,
         "activeOpacity": 0.7,
         "blur": 24,
-        "scale": 1.04
+        "scale": 1.04,
+        "inset": 0.1,
+        "glowRadius": 56,
+        "glowSpread": 12
+      }
+    },
+    "board": {
+      "background": "linear-gradient(135deg, rgba(42, 26, 6, 0.98) 0%, rgba(58, 38, 12, 0.94) 46%, rgba(30, 18, 4, 0.98) 100%)",
+      "wrapper": {
+        "background": "radial-gradient(640px circle at 18% 16%, rgba(255, 236, 168, 0.26) 0%, transparent 62%), radial-gradient(560px circle at 80% 82%, rgba(168, 132, 42, 0.32) 0%, transparent 70%)"
+      },
+      "cell": {
+        "dark": "rgba(48, 30, 8, 0.98)",
+        "light": "rgba(72, 48, 16, 0.96)",
+        "border": "rgba(255, 236, 168, 0.35)",
+        "innerGlow": "rgba(255, 236, 168, 0.2)"
+      },
+      "overlay": {
+        "primary": "rgba(255, 236, 168, 0.34)",
+        "secondary": "rgba(168, 132, 42, 0.28)",
+        "opacity": 0.5,
+        "blendMode": "screen"
+      },
+      "frame": {
+        "border": "1px solid rgba(255, 236, 168, 0.42)",
+        "shadow": "0 36px 78px rgba(28, 16, 2, 0.62)"
       }
     },
     "sounds": {

--- a/pieces/skins/Greece/config.json
+++ b/pieces/skins/Greece/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 270,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(156, 210, 255, 0.76)",
+        "idleOpacity": 0.43,
+        "activeOpacity": 0.7,
+        "blur": 24,
+        "scale": 1.04
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 270,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(255, 236, 168, 0.78)",
+        "idleOpacity": 0.43,
+        "activeOpacity": 0.7,
+        "blur": 24,
+        "scale": 1.04
       }
     },
     "sounds": {

--- a/pieces/skins/Japan/config.json
+++ b/pieces/skins/Japan/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.6
+      },
+      "rotation": {
+        "duration": 260,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(168, 231, 161, 0.72)",
+        "idleOpacity": 0.42,
+        "activeOpacity": 0.68,
+        "blur": 22,
+        "scale": 1.03
       }
     }
   },
@@ -52,6 +65,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.6
+      },
+      "rotation": {
+        "duration": 260,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(154, 220, 144, 0.76)",
+        "idleOpacity": 0.42,
+        "activeOpacity": 0.68,
+        "blur": 22,
+        "scale": 1.03
       }
     }
   }

--- a/pieces/skins/Lavcraft/config.json
+++ b/pieces/skins/Lavcraft/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.9
+      },
+      "rotation": {
+        "duration": 300,
+        "easing": "cubic-bezier(0.25, 1, 0.3, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(82, 226, 198, 0.72)",
+        "idleOpacity": 0.46,
+        "activeOpacity": 0.75,
+        "blur": 30,
+        "scale": 1.08
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 300,
+        "easing": "cubic-bezier(0.25, 1, 0.3, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(154, 124, 250, 0.75)",
+        "idleOpacity": 0.46,
+        "activeOpacity": 0.75,
+        "blur": 30,
+        "scale": 1.08
       }
     },
     "sounds": {

--- a/pieces/skins/Slavic/config.json
+++ b/pieces/skins/Slavic/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.9
+      },
+      "rotation": {
+        "duration": 290,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(255, 152, 92, 0.78)",
+        "idleOpacity": 0.45,
+        "activeOpacity": 0.73,
+        "blur": 27,
+        "scale": 1.06
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 290,
+        "easing": "cubic-bezier(0.22, 1, 0.36, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(136, 210, 255, 0.78)",
+        "idleOpacity": 0.45,
+        "activeOpacity": 0.73,
+        "blur": 27,
+        "scale": 1.06
       }
     },
     "sounds": {

--- a/pieces/skins/premium/config.json
+++ b/pieces/skins/premium/config.json
@@ -24,6 +24,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 300,
+        "easing": "cubic-bezier(0.24, 1, 0.32, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(255, 226, 149, 0.78)",
+        "idleOpacity": 0.46,
+        "activeOpacity": 0.75,
+        "blur": 28,
+        "scale": 1.07
       }
     },
     "sounds": {
@@ -57,6 +70,19 @@
         ],
         "offset": { "x": 0, "y": 0 },
         "scale": 1.8
+      },
+      "rotation": {
+        "duration": 300,
+        "easing": "cubic-bezier(0.24, 1, 0.32, 1)"
+      }
+    },
+    "hero": {
+      "highlight": {
+        "color": "rgba(255, 216, 138, 0.82)",
+        "idleOpacity": 0.46,
+        "activeOpacity": 0.75,
+        "blur": 28,
+        "scale": 1.07
       }
     },
     "sounds": {

--- a/style.css
+++ b/style.css
@@ -337,12 +337,24 @@ body.theme-light .button--primary {
 .skin-grid {
   display: grid;
   gap: 0.85rem;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-@media (max-width: 680px) {
+@media (max-width: 820px) {
   .skin-grid {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .skin-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 420px) {
+  .skin-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }
 
@@ -711,7 +723,7 @@ body.theme-light .connection-warning {
 .board {
   display: grid;
   grid-template-columns: repeat(var(--board-columns, 8), minmax(0, 1fr));
-  grid-auto-rows: 1fr;
+  grid-auto-rows: minmax(0, 1fr);
   width: clamp(320px, 92vw, 720px);
   aspect-ratio: var(--board-columns, 8) / var(--board-rows, 8);
   border-radius: 18px;
@@ -748,6 +760,8 @@ body.theme-light .connection-warning {
   box-shadow: inset 0 0 0 1px var(--cell-inner-glow);
   transition: background 0.2s ease, transform 0.2s ease;
   z-index: 1;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
 }
 
 .cell--light {
@@ -825,6 +839,27 @@ body.theme-light .piece {
   background: linear-gradient(140deg, rgba(107, 154, 255, 0.45), rgba(255, 255, 255, 0.08));
 }
 
+.piece--hero::after {
+  content: "";
+  position: absolute;
+  inset: 16%;
+  border-radius: 999px;
+  background: radial-gradient(circle, var(--hero-highlight-color, rgba(255, 255, 255, 0.6)) 0%, transparent 70%);
+  opacity: var(--hero-highlight-opacity, 0.45);
+  filter: blur(var(--hero-highlight-blur, 22px));
+  transform: scale(var(--hero-highlight-scale, 1));
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  z-index: -2;
+  mix-blend-mode: screen;
+}
+
+.cell:hover .piece--hero::after,
+.cell.cell--selected .piece--hero::after {
+  opacity: var(--hero-highlight-active-opacity, 0.72);
+  transform: scale(calc(var(--hero-highlight-scale, 1) * 1.05));
+}
+
 .cell:hover .piece::before,
 .cell.cell--selected .piece::before {
   transform: scale(1.05);
@@ -833,12 +868,11 @@ body.theme-light .piece {
 
 .piece__image {
   display: block;
-  width: 110%;
-  height: 110%;
+  width: 100%;
+  height: 100%;
   max-width: none;
   pointer-events: none;
   user-select: none;
-  transition: transform 0.2s ease;
   transform-origin: center;
   object-fit: contain;
 }
@@ -864,8 +898,10 @@ body.theme-light .piece {
   max-width: min(260px, 80%);
   border-radius: 18px;
   padding: 1rem 1.25rem 1.15rem;
-  background: rgba(15, 20, 23, 0.92);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+  background: rgba(15, 20, 23, 0.45);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(22px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   display: grid;
   gap: 0.75rem;
   text-align: left;

--- a/style.css
+++ b/style.css
@@ -254,10 +254,38 @@ body.theme-light .button--primary {
   align-items: center;
   justify-content: center;
   padding: clamp(1.25rem, 5vw, 2.75rem) clamp(0.75rem, 4vw, 1.5rem);
-  background: rgba(10, 14, 18, 0.82);
-  backdrop-filter: blur(10px);
+  background: linear-gradient(135deg, rgba(10, 14, 18, 0.86), rgba(10, 18, 24, 0.78));
+  backdrop-filter: blur(12px);
   z-index: 24;
+  overflow-x: hidden;
   overflow-y: auto;
+  isolation: isolate;
+}
+
+.start-overlay::before,
+.start-overlay::after {
+  content: "";
+  position: absolute;
+  inset: -25%;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.55;
+  transform: translate3d(0, 0, 0) scale(1.05);
+  filter: blur(32px);
+  z-index: -1;
+}
+
+.start-overlay::before {
+  background: radial-gradient(520px circle at 24% 30%, rgba(255, 214, 160, 0.32), transparent 70%),
+    radial-gradient(620px circle at 78% 68%, rgba(132, 200, 255, 0.26), transparent 72%);
+  animation: start-parallax-a 26s ease-in-out infinite;
+}
+
+.start-overlay::after {
+  background: radial-gradient(460px circle at 72% 32%, rgba(255, 128, 176, 0.25), transparent 70%),
+    radial-gradient(540px circle at 32% 72%, rgba(96, 236, 212, 0.25), transparent 75%);
+  animation: start-parallax-b 32s ease-in-out infinite;
+  opacity: 0.45;
 }
 
 @media (max-width: 640px) {
@@ -718,6 +746,28 @@ body.theme-light .connection-warning {
 
 .board-wrapper {
   position: relative;
+  width: 100%;
+}
+
+.board-wrapper--intro .board,
+.board-wrapper--intro .laser-overlay,
+.board-wrapper--intro .effects-overlay,
+.board-wrapper--intro .board-atmosphere {
+  animation: board-intro 0.72s cubic-bezier(0.21, 0.94, 0.37, 1) forwards;
+}
+
+.board-atmosphere {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.board-atmosphere--visible {
+  opacity: 1;
 }
 
 .board {
@@ -733,6 +783,7 @@ body.theme-light .connection-warning {
   position: relative;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 70%);
   isolation: isolate;
+  z-index: 1;
 }
 
 .board::after {
@@ -747,6 +798,23 @@ body.theme-light .connection-warning {
   pointer-events: none;
   transition: opacity 0.4s ease;
   z-index: 0;
+}
+
+.board-atmosphere__particle {
+  position: absolute;
+  top: var(--particle-start-y, 0%);
+  left: var(--particle-start-x, 50%);
+  width: calc(var(--particle-size, 1) * 0.85vmin);
+  height: calc(var(--particle-size, 1) * 0.85vmin);
+  border-radius: 999px;
+  background: radial-gradient(circle at center, var(--particle-color, rgba(255, 255, 255, 0.5)) 0%, transparent 70%);
+  opacity: 0;
+  transform: translate3d(-50%, -50%, 0) scale(var(--particle-scale-start, 0.7));
+  animation: board-particle-drift var(--particle-duration, 18s) linear infinite;
+  animation-delay: calc(var(--particle-delay, 0s) * -1);
+  mix-blend-mode: screen;
+  filter: blur(var(--particle-blur, 0px));
+  will-change: transform, opacity;
 }
 
 .cell {
@@ -845,10 +913,10 @@ body.theme-light .piece {
   inset: var(--hero-highlight-inset, 12%);
   border-radius: 999px;
   background:
-    radial-gradient(circle at center, rgba(255, 255, 255, 0.45) 0%, transparent 65%),
-    radial-gradient(circle at center, var(--hero-highlight-color, rgba(255, 255, 255, 0.7)) 0%, transparent 72%);
-  opacity: var(--hero-highlight-opacity, 0.6);
-  filter: blur(var(--hero-highlight-blur, 26px));
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.6) 0%, transparent 42%),
+    radial-gradient(circle at center, var(--hero-highlight-color, rgba(255, 255, 255, 0.78)) 0%, transparent 72%),
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.25) 0%, transparent 100%);
+  filter: blur(var(--hero-highlight-blur, 26px)) saturate(1.18);
   transform: scale(var(--hero-highlight-scale, 1.02));
   transition: opacity 0.42s ease, transform 0.42s ease;
   box-shadow: 0 0 var(--hero-highlight-glow-radius, 46px)
@@ -859,10 +927,27 @@ body.theme-light .piece {
   mix-blend-mode: screen;
 }
 
+.piece--hero-glowing::after {
+  opacity: var(--hero-highlight-opacity, 0.6);
+  animation: hero-pulse var(--hero-highlight-pulse, 4.6s) ease-in-out infinite alternate;
+}
+
 .cell:hover .piece--hero::after,
 .cell.cell--selected .piece--hero::after {
   opacity: var(--hero-highlight-active-opacity, 0.72);
   transform: scale(calc(var(--hero-highlight-scale, 1.02) * 1.05));
+}
+
+.piece--hero-glowing .piece__image {
+  filter: drop-shadow(0 0 0.75rem var(--hero-highlight-color, rgba(255, 255, 255, 0.65)))
+    drop-shadow(0 0 0.35rem rgba(255, 255, 255, 0.4))
+    brightness(1.08) saturate(1.08);
+  transition: filter 0.4s ease;
+}
+
+.cell:hover .piece--hero-glowing .piece__image,
+.cell.cell--selected .piece--hero-glowing .piece__image {
+  filter: drop-shadow(0 0 1.1rem var(--hero-highlight-color, rgba(255, 255, 255, 0.82)));
 }
 
 .cell:hover .piece::before,
@@ -936,6 +1021,35 @@ body.theme-light .piece {
   --laser-glow-color: rgba(255, 94, 94, 0.55);
   --laser-impact-gradient: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, var(--laser-core-color) 45%, rgba(255, 94, 94, 0) 70%);
   --laser-impact-shadow: rgba(255, 94, 94, 0.6);
+  --laser-impact-glow: rgba(255, 94, 94, 0.55);
+  --laser-impact-x: 50%;
+  --laser-impact-y: 50%;
+}
+
+.laser-overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.88);
+  background:
+    radial-gradient(circle at var(--laser-impact-x, 50%) var(--laser-impact-y, 50%), rgba(255, 255, 255, 0.72) 0%, transparent 32%),
+    radial-gradient(circle at var(--laser-impact-x, 50%) var(--laser-impact-y, 50%), var(--laser-impact-glow, rgba(255, 94, 94, 0.55)) 0%, transparent 64%);
+  filter: blur(24px) saturate(1.1);
+  transition: opacity 0.25s ease;
+}
+
+.laser-overlay--armed::after {
+  opacity: 0.35;
+}
+
+.laser-overlay--impact {
+  animation: laser-impact-flare 0.55s ease-out;
+}
+
+.laser-overlay--impact::after {
+  animation: laser-impact-glow 0.82s cubic-bezier(0.19, 1, 0.3, 1) forwards;
 }
 
 .effects-overlay {
@@ -1753,6 +1867,81 @@ body.theme-light .board-action {
   }
 }
 
+@keyframes board-intro {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 16px, 0) scale(0.94);
+    filter: blur(10px);
+  }
+  55% {
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes board-particle-drift {
+  0% {
+    opacity: 0;
+    transform: translate3d(-50%, -50%, 0) scale(var(--particle-scale-start, 0.7));
+  }
+  10% {
+    opacity: var(--particle-opacity, 0.35);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(
+        calc(-50% + var(--particle-drift-x, 0%)),
+        calc(-50% + var(--particle-drift-y, 22%)),
+        0
+      )
+      scale(var(--particle-scale-end, 1.12));
+  }
+}
+
+@keyframes start-parallax-a {
+  0% {
+    transform: translate3d(-2%, -1%, 0) scale(1.04);
+  }
+  50% {
+    transform: translate3d(1.5%, 2%, 0) scale(1.06);
+  }
+  100% {
+    transform: translate3d(-1%, 1.5%, 0) scale(1.04);
+  }
+}
+
+@keyframes start-parallax-b {
+  0% {
+    transform: translate3d(2%, 1%, 0) scale(1.03);
+  }
+  45% {
+    transform: translate3d(-1.5%, -1.5%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(1%, -2%, 0) scale(1.03);
+  }
+}
+
+@keyframes hero-pulse {
+  0% {
+    opacity: var(--hero-highlight-opacity, 0.6);
+    transform: scale(calc(var(--hero-highlight-scale, 1.02) * 0.98));
+  }
+  50% {
+    opacity: var(--hero-highlight-active-opacity, 0.78);
+    transform: scale(calc(var(--hero-highlight-scale, 1.02) * 1.04));
+  }
+  100% {
+    opacity: var(--hero-highlight-opacity, 0.6);
+    transform: scale(calc(var(--hero-highlight-scale, 1.02) * 1.0));
+  }
+}
+
 @keyframes laser-trace {
   0% {
     opacity: 0;
@@ -1779,6 +1968,35 @@ body.theme-light .board-action {
   100% {
     transform: translate(-50%, -50%) scale(1);
     opacity: 0.6;
+  }
+}
+
+@keyframes laser-impact-glow {
+  0% {
+    opacity: 0.9;
+    transform: scale(0.82);
+    filter: blur(18px) saturate(1.25);
+  }
+  60% {
+    opacity: 0.35;
+    filter: blur(32px) saturate(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.18);
+    filter: blur(44px) saturate(0.9);
+  }
+}
+
+@keyframes laser-impact-flare {
+  0% {
+    filter: drop-shadow(0 0 28px var(--laser-impact-glow, rgba(255, 94, 94, 0.55)));
+  }
+  60% {
+    filter: drop-shadow(0 0 12px var(--laser-impact-glow, rgba(255, 94, 94, 0.32)));
+  }
+  100% {
+    filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -826,7 +826,7 @@ body.theme-light .piece {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 65%);
   filter: blur(0.5px);
   opacity: 0.65;
-  z-index: -1;
+  z-index: -2;
   pointer-events: none;
   transition: transform 0.25s ease, opacity 0.25s ease;
 }
@@ -842,22 +842,27 @@ body.theme-light .piece {
 .piece--hero::after {
   content: "";
   position: absolute;
-  inset: 16%;
+  inset: var(--hero-highlight-inset, 12%);
   border-radius: 999px;
-  background: radial-gradient(circle, var(--hero-highlight-color, rgba(255, 255, 255, 0.6)) 0%, transparent 70%);
-  opacity: var(--hero-highlight-opacity, 0.45);
-  filter: blur(var(--hero-highlight-blur, 22px));
-  transform: scale(var(--hero-highlight-scale, 1));
-  transition: opacity 0.35s ease, transform 0.35s ease;
+  background:
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.45) 0%, transparent 65%),
+    radial-gradient(circle at center, var(--hero-highlight-color, rgba(255, 255, 255, 0.7)) 0%, transparent 72%);
+  opacity: var(--hero-highlight-opacity, 0.6);
+  filter: blur(var(--hero-highlight-blur, 26px));
+  transform: scale(var(--hero-highlight-scale, 1.02));
+  transition: opacity 0.42s ease, transform 0.42s ease;
+  box-shadow: 0 0 var(--hero-highlight-glow-radius, 46px)
+    var(--hero-highlight-glow-spread, 12px)
+    var(--hero-highlight-color, rgba(255, 255, 255, 0.68));
   pointer-events: none;
-  z-index: -2;
+  z-index: -1;
   mix-blend-mode: screen;
 }
 
 .cell:hover .piece--hero::after,
 .cell.cell--selected .piece--hero::after {
   opacity: var(--hero-highlight-active-opacity, 0.72);
-  transform: scale(calc(var(--hero-highlight-scale, 1) * 1.05));
+  transform: scale(calc(var(--hero-highlight-scale, 1.02) * 1.05));
 }
 
 .cell:hover .piece::before,


### PR DESCRIPTION
## Summary
- keep the board grid square by locking cell aspect ratios and preventing overflow distortion
- rescale piece artwork without affecting layout while maintaining the 15% size increase
- drive rotations through a shared scale-aware transform with web animations and CSS fallbacks for smoother turns

## Testing
- Not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123484c6248320941c5a15057c7aca)